### PR TITLE
Deploy Pypi artifacts on tag builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,6 @@ deploy:
   - provider: script
     script: tox -e build -e upload
     on:
-      branch: matthieucan/deploy-on-tag
+      branch: master
       tags: true
       condition: ${DEPLOY} = true

--- a/tox.ini
+++ b/tox.ini
@@ -128,6 +128,5 @@ deps = twine
 passenv = TWINE_USERNAME TWINE_PASSWORD
 setenv =
     TWINE_NON_INTERACTIVE = 1
-    TWINE_REPOSITORY = testpypi
 commands =
     python -m twine upload dist/*


### PR DESCRIPTION
4 things happen now on tag builds, as part of the deployment process:
- Documentation is built.
- Documentation is pushed to `gh-pages`.
- Source dist and wheel are built.
- Source dist and wheel are uploaded to Pypi.