### PR TITLE
Fix URLs for Pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,4 @@ list of naming conventions, and more!
 ## Contributing
 
 Want to fix a bug, improve the docs, or add a new feature? That's awesome! Please read
-the [contributing document](CONTRIBUTING.md).
+the [contributing document](https://github.com/PicnicSupermarket/diepvries/blob/master/CONTRIBUTING.md).

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = diepvries
 url = https://github.com/PicnicSupermarket/diepvries
 project_urls =
-    Documentation = https://diepvries.picnic.app/
+    Documentation = https://diepvries.picnic.tech/
     Source Code = https://github.com/PicnicSupermarket/diepvries
     Issue Tracker = https://github.com/PicnicSupermarket/diepvries/issues
 description = diepvries - Picnic Data Vault framework


### PR DESCRIPTION
Use absolute URL, so it is clickable from the Pypi page.