### PR TITLE
Documentation: Tell GitHub to also serve folders prefixed with _

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -86,6 +86,7 @@ max-attributes=10
 # DOCUMENTATION #
 
 [testenv:doc]
+allowlist_externals = touch
 deps =
     sphinx~=3.5
     sphinx-autodoc-typehints~=1.11
@@ -111,6 +112,8 @@ commands =
         -D html_theme_options.sidebar_collapse="false" \
         doc \
         doc/html
+    # Tell GitHub to also serve folders prefixed with _
+    touch doc/html/.nojekyll
 
 [testenv:serve-docs]
 skip_install = true


### PR DESCRIPTION
See https://github.blog/2009-12-29-bypassing-jekyll-on-github-pages/
Sphinx uses multiple folders prefixed with `_`; by default GitHub pages doesn't serve them as they are considered Jekyll special folders.