### PR TITLE
Apply LISTAGG to r_source in link/hub DML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Apply LISTAGG to r_source in link/hub DML (#23)
 
 ## [0.6.1] - 2021-08-19
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Apply LISTAGG to r_source in link/hub DML (#23)
+- Apply LISTAGG to r_source in link/hub DML (#23).
 
 ## [0.6.1] - 2021-08-19
 ### Added

--- a/src/diepvries/hub.py
+++ b/src/diepvries/hub.py
@@ -85,19 +85,20 @@ class Hub(Table):
         staging_fields = ", ".join(
             format_fields_for_select(fields=self.fields, table_alias="staging")
         )
-        source_fields = [
-            field
-            for field in self.fields
-            if field.role != FieldRole.HASHKEY
-            and field.name != METADATA_FIELDS["record_source"]
-        ]
-        source_fields_sql = ", ".join(format_fields_for_select(fields=source_fields))
+        source_fields = ", ".join(
+            [
+                field.name
+                for field in self.fields
+                if field.role != FieldRole.HASHKEY
+                and field.name != METADATA_FIELDS["record_source"]
+            ]
+        )
 
         sql_placeholders = {
             "source_hashkey_field": hashkey.name,
             "target_hashkey_field": hashkey.name,
             "record_source_field": METADATA_FIELDS["record_source"],
-            "source_fields": source_fields_sql,
+            "source_fields": source_fields,
             "target_fields": target_fields,
             "staging_source_fields": staging_fields,
         }

--- a/src/diepvries/hub.py
+++ b/src/diepvries/hub.py
@@ -2,7 +2,7 @@
 
 from typing import Dict
 
-from . import FIELD_SUFFIX, TEMPLATES_DIR, FieldRole
+from . import FIELD_SUFFIX, METADATA_FIELDS, TEMPLATES_DIR, FieldRole
 from .table import Table
 from .template_sql.sql_formulas import format_fields_for_select
 
@@ -81,16 +81,24 @@ class Hub(Table):
         """
         hashkey = next(hashkey for hashkey in self.fields_by_role[FieldRole.HASHKEY])
 
-        fields = ", ".join(format_fields_for_select(fields=self.fields))
+        target_fields = ", ".join(format_fields_for_select(fields=self.fields))
         staging_fields = ", ".join(
             format_fields_for_select(fields=self.fields, table_alias="staging")
         )
+        source_fields = [
+            field
+            for field in self.fields
+            if field.role != FieldRole.HASHKEY
+            and field.name != METADATA_FIELDS["record_source"]
+        ]
+        source_fields_sql = ", ".join(format_fields_for_select(fields=source_fields))
 
         sql_placeholders = {
             "source_hashkey_field": hashkey.name,
             "target_hashkey_field": hashkey.name,
-            "source_fields": fields,
-            "target_fields": fields,
+            "record_source_field": METADATA_FIELDS["record_source"],
+            "source_fields": source_fields_sql,
+            "target_fields": target_fields,
             "staging_source_fields": staging_fields,
         }
         sql_placeholders.update(super().sql_placeholders)

--- a/src/diepvries/link.py
+++ b/src/diepvries/link.py
@@ -98,19 +98,20 @@ class Link(Table):
         staging_fields = ", ".join(
             format_fields_for_select(fields=self.fields, table_alias="staging")
         )
-        source_fields = [
-            field
-            for field in self.fields
-            if field.role != FieldRole.HASHKEY
-            and field.name != METADATA_FIELDS["record_source"]
-        ]
-        source_fields_sql = ", ".join(format_fields_for_select(fields=source_fields))
+        source_fields = ", ".join(
+            [
+                field.name
+                for field in self.fields
+                if field.role != FieldRole.HASHKEY
+                and field.name != METADATA_FIELDS["record_source"]
+            ]
+        )
 
         sql_placeholders = {
             "source_hashkey_field": hashkey.name,
             "target_hashkey_field": hashkey.name,
             "record_source_field": METADATA_FIELDS["record_source"],
-            "source_fields": source_fields_sql,
+            "source_fields": source_fields,
             "target_fields": target_fields,
             "staging_source_fields": staging_fields,
         }

--- a/src/diepvries/template_sql/hub_link_dml.sql
+++ b/src/diepvries/template_sql/hub_link_dml.sql
@@ -1,6 +1,12 @@
 MERGE INTO {target_schema}.{target_table} AS target
   USING (
         SELECT DISTINCT
+          {source_hashkey_field},
+          -- If multiple sources for the same hashkey are received, their values
+          -- are concatenated using a comma.
+          LISTAGG(DISTINCT {record_source_field}, ',')
+              WITHIN GROUP (ORDER BY {record_source_field})
+              OVER (PARTITION BY {source_hashkey_field}) AS {record_source_field},
           {source_fields}
         FROM {staging_schema}.{staging_table}
         ) AS staging ON (target.{target_hashkey_field} = staging.{source_hashkey_field})

--- a/test/sql/expected_result_data_vault_load.sql
+++ b/test/sql/expected_result_data_vault_load.sql
@@ -6,7 +6,13 @@ CREATE OR REPLACE TABLE dv_stg.orders_20190806_000000
 MERGE INTO dv.h_customer AS target
   USING (
         SELECT DISTINCT
-          h_customer_hashkey, r_timestamp, r_source, customer_id
+          h_customer_hashkey,
+          -- If multiple sources for the same hashkey are received, their values
+          -- are concatenated using a comma.
+          LISTAGG(DISTINCT r_source, ',')
+              WITHIN GROUP (ORDER BY r_source)
+              OVER (PARTITION BY h_customer_hashkey) AS r_source,
+          r_timestamp, customer_id
         FROM dv_stg.orders_20190806_000000
         ) AS staging ON (target.h_customer_hashkey = staging.h_customer_hashkey)
   WHEN NOT MATCHED THEN INSERT (h_customer_hashkey, r_timestamp, r_source, customer_id)
@@ -15,7 +21,13 @@ MERGE INTO dv.h_customer AS target
 MERGE INTO dv.h_customer AS target
   USING (
         SELECT DISTINCT
-          h_customer_role_playing_hashkey, r_timestamp, r_source, customer_role_playing_id
+          h_customer_role_playing_hashkey,
+          -- If multiple sources for the same hashkey are received, their values
+          -- are concatenated using a comma.
+          LISTAGG(DISTINCT r_source, ',')
+              WITHIN GROUP (ORDER BY r_source)
+              OVER (PARTITION BY h_customer_role_playing_hashkey) AS r_source,
+          r_timestamp, customer_role_playing_id
         FROM dv_stg.orders_20190806_000000
         ) AS staging ON (target.h_customer_hashkey = staging.h_customer_role_playing_hashkey)
   WHEN NOT MATCHED THEN INSERT (h_customer_hashkey, r_timestamp, r_source, customer_id)
@@ -24,7 +36,13 @@ MERGE INTO dv.h_customer AS target
 MERGE INTO dv.h_order AS target
   USING (
         SELECT DISTINCT
-          h_order_hashkey, r_timestamp, r_source, order_id
+          h_order_hashkey,
+          -- If multiple sources for the same hashkey are received, their values
+          -- are concatenated using a comma.
+          LISTAGG(DISTINCT r_source, ',')
+              WITHIN GROUP (ORDER BY r_source)
+              OVER (PARTITION BY h_order_hashkey) AS r_source,
+          r_timestamp, order_id
         FROM dv_stg.orders_20190806_000000
         ) AS staging ON (target.h_order_hashkey = staging.h_order_hashkey)
   WHEN NOT MATCHED THEN INSERT (h_order_hashkey, r_timestamp, r_source, order_id)
@@ -33,7 +51,13 @@ MERGE INTO dv.h_order AS target
 MERGE INTO dv.l_order_customer AS target
   USING (
         SELECT DISTINCT
-          l_order_customer_hashkey, h_order_hashkey, h_customer_hashkey, order_id, customer_id, ck_test_string, ck_test_timestamp, r_timestamp, r_source
+          l_order_customer_hashkey,
+          -- If multiple sources for the same hashkey are received, their values
+          -- are concatenated using a comma.
+          LISTAGG(DISTINCT r_source, ',')
+              WITHIN GROUP (ORDER BY r_source)
+              OVER (PARTITION BY l_order_customer_hashkey) AS r_source,
+          h_order_hashkey, h_customer_hashkey, order_id, customer_id, ck_test_string, ck_test_timestamp, r_timestamp
         FROM dv_stg.orders_20190806_000000
         ) AS staging ON (target.l_order_customer_hashkey = staging.l_order_customer_hashkey)
   WHEN NOT MATCHED THEN INSERT (l_order_customer_hashkey, h_order_hashkey, h_customer_hashkey, order_id, customer_id, ck_test_string, ck_test_timestamp, r_timestamp, r_source)
@@ -42,7 +66,13 @@ MERGE INTO dv.l_order_customer AS target
 MERGE INTO dv.l_order_customer_role_playing AS target
   USING (
         SELECT DISTINCT
-          l_order_customer_role_playing_hashkey, h_order_hashkey, h_customer_role_playing_hashkey, order_id, customer_role_playing_id, ck_test_string, ck_test_timestamp, r_timestamp, r_source
+          l_order_customer_role_playing_hashkey,
+          -- If multiple sources for the same hashkey are received, their values
+          -- are concatenated using a comma.
+          LISTAGG(DISTINCT r_source, ',')
+              WITHIN GROUP (ORDER BY r_source)
+              OVER (PARTITION BY l_order_customer_role_playing_hashkey) AS r_source,
+          h_order_hashkey, h_customer_role_playing_hashkey, order_id, customer_role_playing_id, ck_test_string, ck_test_timestamp, r_timestamp
         FROM dv_stg.orders_20190806_000000
         ) AS staging ON (target.l_order_customer_role_playing_hashkey = staging.l_order_customer_role_playing_hashkey)
   WHEN NOT MATCHED THEN INSERT (l_order_customer_role_playing_hashkey, h_order_hashkey, h_customer_role_playing_hashkey, order_id, customer_role_playing_id, ck_test_string, ck_test_timestamp, r_timestamp, r_source)

--- a/test/sql/expected_result_hub.sql
+++ b/test/sql/expected_result_hub.sql
@@ -1,7 +1,13 @@
 MERGE INTO dv.h_customer AS target
   USING (
         SELECT DISTINCT
-          h_customer_hashkey, r_timestamp, r_source, customer_id
+          h_customer_hashkey,
+          -- If multiple sources for the same hashkey are received, their values
+          -- are concatenated using a comma.
+          LISTAGG(DISTINCT r_source, ',')
+              WITHIN GROUP (ORDER BY r_source)
+              OVER (PARTITION BY h_customer_hashkey) AS r_source,
+          r_timestamp, customer_id
         FROM dv_stg.orders_20190806_000000
         ) AS staging ON (target.h_customer_hashkey = staging.h_customer_hashkey)
   WHEN NOT MATCHED THEN INSERT (h_customer_hashkey, r_timestamp, r_source, customer_id)

--- a/test/sql/expected_result_link.sql
+++ b/test/sql/expected_result_link.sql
@@ -1,7 +1,13 @@
 MERGE INTO dv.l_order_customer AS target
   USING (
         SELECT DISTINCT
-          l_order_customer_hashkey, h_order_hashkey, h_customer_hashkey, order_id, customer_id, ck_test_string, ck_test_timestamp, r_timestamp, r_source
+          l_order_customer_hashkey,
+          -- If multiple sources for the same hashkey are received, their values
+          -- are concatenated using a comma.
+          LISTAGG(DISTINCT r_source, ',')
+              WITHIN GROUP (ORDER BY r_source)
+              OVER (PARTITION BY l_order_customer_hashkey) AS r_source,
+          h_order_hashkey, h_customer_hashkey, order_id, customer_id, ck_test_string, ck_test_timestamp, r_timestamp
         FROM dv_stg.orders_20190806_000000
         ) AS staging ON (target.l_order_customer_hashkey = staging.l_order_customer_hashkey)
   WHEN NOT MATCHED THEN INSERT (l_order_customer_hashkey, h_order_hashkey, h_customer_hashkey, order_id, customer_id, ck_test_string, ck_test_timestamp, r_timestamp, r_source)

--- a/test/sql/expected_result_role_playing_hub.sql
+++ b/test/sql/expected_result_role_playing_hub.sql
@@ -1,7 +1,13 @@
 MERGE INTO dv.h_customer AS target
   USING (
         SELECT DISTINCT
-          h_customer_role_playing_hashkey, r_timestamp, r_source, customer_role_playing_id
+          h_customer_role_playing_hashkey,
+          -- If multiple sources for the same hashkey are received, their values
+          -- are concatenated using a comma.
+          LISTAGG(DISTINCT r_source, ',')
+              WITHIN GROUP (ORDER BY r_source)
+              OVER (PARTITION BY h_customer_role_playing_hashkey) AS r_source,
+          r_timestamp, customer_role_playing_id
         FROM dv_stg.orders_20190806_000000
         ) AS staging ON (target.h_customer_hashkey = staging.h_customer_role_playing_hashkey)
   WHEN NOT MATCHED THEN INSERT (h_customer_hashkey, r_timestamp, r_source, customer_id)


### PR DESCRIPTION
## Context

While testing the version `0.6.1` in our DV processes, I noticed that https://github.com/PicnicSupermarket/diepvries/pull/19 introduced an unexpected behaviour that can either generate duplicates in hubs or make the DV load to fail.

It is pretty common for a single execution of a domain/DV process to fetch data from multiple endpoints (example: domains that fetch data from multiple fulfillment centers). 

Example:
- A DV process fetches the location of each article in the fulfillment center;
- Each fulfillment center has its own endpoint;
- This process populates a link `l_fulfillment_center_article_location`;
- Article `1234` exists in 3 fulfillment centers (A, B and C);
- When we populate the link, we want the `r_source` of each record to point to the instance from which it was fetched (the row where `fulfillment_center = A` should have the FCA endpoint instance as source, the row where `fulfillment_center=B` should have FCB endpoint instance as source, and so on );
- Although, when populating the hub `article`, we have 3 rows for article `1234`, each of them pointing to a different endpoint instance (FCA, FCB, FCC) and we only want one of these rows to be loaded.
- Applying a `DISTINCT` does not work given that each record has a different source, so an aggregation must be applied.

## Implementation

Added a `LISTAGG` to `r_source` field to allow a hub to be sourced from multiple endpoint instances.