### PR TITLE
Always deploy documentation on master builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ deploy:
     keep_history: true
     on:
       branch: master
-      tags: true
       condition: ${DEPLOY} = true
   - provider: script
     script: tox -e build -e upload


### PR DESCRIPTION
Documentation website does not need a tag build (i.e. a release) to be deployed, it should reflect the latest documentation improvements in `master`.