### PR TITLE
Add pre-commit tool

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+    -   id: check-added-large-files
+        files: 'src/diepvries/'        
+-   repo: https://github.com/psf/black
+    rev: '22.6.0'
+    hooks:
+      - id: black
+        args: [--check, "."]
+-   repo: https://github.com/pycqa/flake8
+    rev: '4.0.1'
+    hooks:
+    -   id: flake8
+        additional_dependencies:
+          - darglint
+          - flake8-docstrings
+          - flake8-isort
+        files: 'src/diepvries/'
+-   repo: https://github.com/PyCQA/pylint
+    rev: 'v2.14.5'
+    hooks:
+    -   id: pylint
+        additional_dependencies:
+          - snowflake-connector-python
+        args: [--rcfile=tox.ini]
+        files: 'src/diepvries/' 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,4 +79,13 @@ And then run everything with:
 tox
 ```
 
+To automatically run checks before you commit your changes you should install and run **pre-commit**:
+
+```shell
+pip install -U pre-commit
+pre-commit install
+```
+
+now ```pre-commit``` will run automatically on ```git commit```.
+
 If you have any question or doubt, don't hesitate to open an Issue, we're happy to help!

--- a/tox.ini
+++ b/tox.ini
@@ -13,25 +13,17 @@ commands = pytest
 [testenv:lint]
 description = Lint Python source code
 deps =
-  {[testenv:black]deps}
-  {[testenv:flake8]deps}
-  {[testenv:pylint]deps}
+  pre-commit
 commands =
-  {[testenv:black]commands}
-  {[testenv:flake8]commands}
-  {[testenv:pylint]commands}
+  pre-commit run --all-files --show-diff-on-failure
 
 [testenv:black]
-deps = black
-commands = black --check .
+deps = {[testenv:lint]deps}
+commands = pre-commit run black --all-files --show-diff-on-failure
 
 [testenv:flake8]
-deps =
-    darglint
-    flake8
-    flake8-docstrings
-    flake8-isort
-commands = flake8 src/diepvries
+deps = {[testenv:lint]deps}
+commands = pre-commit run flake8 --all-files --show-diff-on-failure
 
 [flake8]
 exclude = .tox
@@ -67,29 +59,28 @@ use_parentheses=True
 line_length=88
 
 [testenv:pylint]
-deps = pylint
-commands = pylint --rcfile=tox.ini src/diepvries
+deps = {[testenv:lint]deps}
+commands = pre-commit run pylint --all-files --show-diff-on-failure
 
-# pylint
-[MESSAGES CONTROL]
+[pylint]
+## MESSAGES CONTROL
 disable =
     duplicate-code
 
-[BASIC]
+## BASIC
 good-names=e
 
-[DESIGN]
+## DESIGN
 max-args=10
 max-attributes=10
-# end pylint
 
 # DOCUMENTATION #
 
 [testenv:doc]
 allowlist_externals = touch
 deps =
-    sphinx~=3.5
-    sphinx-autodoc-typehints~=1.11
+    sphinx
+    sphinx-autodoc-typehints
 commands =
     # Build apidoc
     sphinx-apidoc --implicit-namespaces -M -t doc_templates --separate -o doc/api src/diepvries


### PR DESCRIPTION
In this commit, we add the pre-commit tool to
improve the Software Development Lifecycle
of the project by automatically running checks
(linting & formatting) before one commits their
changes.

Specifically:
- black, flake8 and pylint were adjusted in
tox to run as pre-commit hooks.
Additionally, the check-added-large-files
commit hook was added (prevents giant
files from being committed).

- We fixed doc build and pylint failing:
* Docs were failing with the pinned versions of
their dependencies (sphinx,
sphinx-autodoc-typehints).
So we unpinned the dependencies (also good
as best practice).
* Pylint was not able to read the sections
related to its configuration in tox.ini.
So we added a pylint section in tox.ini with the
necessary key/value entries.
* the snowflake-connector-python was
needed as a dependency for pylint (otherwise
we got an ImportError)

- We updated the CONTRIBUTING.md with
how to install pre-commit