### PR TITLE
Fix tox by giving `passenv` a comma separated list

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -130,7 +130,7 @@ commands =
 
 [testenv:upload]
 deps = twine
-passenv = TWINE_USERNAME TWINE_PASSWORD
+passenv = TWINE_USERNAME, TWINE_PASSWORD
 setenv =
     TWINE_NON_INTERACTIVE = 1
 commands =


### PR DESCRIPTION
Due to a regression in tox (see https://github.com/tox-dev/tox/issues/2615), `passenv` now needs a comma separated list.

This is necessary for our CI to upload to PyPI automagically.