### PR TITLE
Fix `tox -e upload` by separating build and upload steps

### DIFF
--- a/.github/workflows/pypi-build-and-deploy.yml
+++ b/.github/workflows/pypi-build-and-deploy.yml
@@ -25,5 +25,7 @@ jobs:
           python-version: 3.9
       - name: Install dependencies
         run: python -m pip install tox
-      - name: Run tox
-        run: python -m tox -e build -e upload
+      - name: Run tox build
+        run: python -m tox -e build
+      - name: Run tox upload
+        run: python -m tox -e upload


### PR DESCRIPTION
For some reason, `tox -e build -e upload` started failing because the `upload` step would run _before_ the `build` step. As it turns out, you can't upload something that doesn't exist yet. Fix this by separating the build and upload steps.