### PR TITLE
Add validation for driving keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add validation for driving keys
 
 ## [0.6.4] - 2023-03-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Add validation for driving keys
+- Add validation for driving keys (#41)
 
 ## [0.6.4] - 2023-03-01
 ### Added

--- a/src/diepvries/driving_key_field.py
+++ b/src/diepvries/driving_key_field.py
@@ -46,20 +46,22 @@ class DrivingKeyField:
         2. Parent table name has a prefix within TABLE_PREFIXES[TableType.LINK].
 
         Raises:
-            RuntimeError: If one of the checks fails.
+            AssertionError: If one of the checks fails.
         """
         satellite_name_prefix = next(
             split_part for split_part in self.satellite_name.split("_")
         )
-        assert satellite_name_prefix in TABLE_PREFIXES[TableType.SATELLITE], \
-            f"'{self.satellite_name}': Satellite name with incorrect prefix. " \
-            f"Got '{satellite_name_prefix}', " \
+        assert satellite_name_prefix in TABLE_PREFIXES[TableType.SATELLITE], (
+            f"'{self.satellite_name}': Satellite name with incorrect prefix. "
+            f"Got '{satellite_name_prefix}', "
             f"but expects '{TABLE_PREFIXES[TableType.SATELLITE]}'."
+        )
 
         parent_table_name_prefix = next(
             split_part for split_part in self.parent_table_name.split("_")
         )
-        assert parent_table_name_prefix in TABLE_PREFIXES[TableType.LINK], \
-            f"'{self.satellite_name}': Parent table with incorrect prefix. " \
-            f"Got '{parent_table_name_prefix}', " \
+        assert parent_table_name_prefix in TABLE_PREFIXES[TableType.LINK], (
+            f"'{self.satellite_name}': Parent table with incorrect prefix. "
+            f"Got '{parent_table_name_prefix}', "
             f"but expects '{TABLE_PREFIXES[TableType.LINK]}'."
+        )

--- a/src/diepvries/driving_key_field.py
+++ b/src/diepvries/driving_key_field.py
@@ -51,19 +51,15 @@ class DrivingKeyField:
         satellite_name_prefix = next(
             split_part for split_part in self.satellite_name.split("_")
         )
-        if satellite_name_prefix not in TABLE_PREFIXES[TableType.SATELLITE]:
-            raise RuntimeError(
-                f"'{self.satellite_name}': Satellite name with incorrect prefix. "
-                f"Got '{satellite_name_prefix}', "
-                f"but expects '{TABLE_PREFIXES[TableType.SATELLITE]}'."
-            )
+        assert satellite_name_prefix in TABLE_PREFIXES[TableType.SATELLITE], \
+            f"'{self.satellite_name}': Satellite name with incorrect prefix. " \
+            f"Got '{satellite_name_prefix}', " \
+            f"but expects '{TABLE_PREFIXES[TableType.SATELLITE]}'."
 
         parent_table_name_prefix = next(
             split_part for split_part in self.parent_table_name.split("_")
         )
-        if parent_table_name_prefix not in TABLE_PREFIXES[TableType.LINK]:
-            raise RuntimeError(
-                f"'{self.satellite_name}': Parent table with incorrect prefix. "
-                f"Got '{parent_table_name_prefix}', "
-                f"but expects '{TABLE_PREFIXES[TableType.LINK]}'."
-            )
+        assert parent_table_name_prefix in TABLE_PREFIXES[TableType.LINK], \
+            f"'{self.satellite_name}': Parent table with incorrect prefix. " \
+            f"Got '{parent_table_name_prefix}', " \
+            f"but expects '{TABLE_PREFIXES[TableType.LINK]}'."

--- a/src/diepvries/driving_key_field.py
+++ b/src/diepvries/driving_key_field.py
@@ -2,6 +2,8 @@
 
 from dataclasses import dataclass
 
+from . import TABLE_PREFIXES, TableType
+
 
 @dataclass
 class DrivingKeyField:
@@ -12,12 +14,20 @@ class DrivingKeyField:
     defined by a subset of hashkeys.
     """
 
-    #: Name of parent table in the database (always a Link).
-    parent_table_name: str
-    #: Column name in the database.
-    name: str
-    #: Name of the satellite where this field represents a driving key.
-    satellite_name: str
+    def __init__(self, parent_table_name: str, name: str, satellite_name: str):
+        """Instantiate a DrivingKeyField.
+
+        Args:
+            parent_table_name: Name of parent table in the database (always a Link).
+            name: Column name in the database.
+            satellite_name: Name of the satellite where this field
+                represents a driving key.
+        """
+        self.parent_table_name = parent_table_name
+        self.name = name
+        self.satellite_name = satellite_name
+
+        self._validate()
 
     def __str__(self) -> str:
         """Representation of a DrivingKeyField object as a string.
@@ -31,3 +41,34 @@ class DrivingKeyField:
             f"{type(self).__name__}: field_name={self.name}, "
             f"satellite={self.satellite_name}"
         )
+
+    def _validate(self):
+        """Validate driving key
+
+        Perform the following checks:
+        1. Satellite name has a prefix within TABLE_PREFIXES[TableType.SATELLITE]
+        2. Parent table name has a prefix within TABLE_PREFIXES[TableType.LINK]
+
+        Raises:
+            RuntimeError: If one of the checks fails.
+        """
+
+        satellite_name_prefix = next(
+            split_part for split_part in self.satellite_name.split("_")
+        )
+        if satellite_name_prefix not in TABLE_PREFIXES[TableType.SATELLITE]:
+            raise RuntimeError(
+                f"'{self.satellite_name}': Satellite name with incorrect prefix. "
+                f"Got '{satellite_name_prefix}', "
+                f"but expects '{TABLE_PREFIXES[TableType.SATELLITE]}'."
+            )
+
+        parent_table_name_prefix = next(
+            split_part for split_part in self.parent_table_name.split("_")
+        )
+        if parent_table_name_prefix not in TABLE_PREFIXES[TableType.LINK]:
+            raise RuntimeError(
+                f"'{self.satellite_name}': Parent table with incorrect prefix. "
+                f"Got '{parent_table_name_prefix}', "
+                f"but expects '{TABLE_PREFIXES[TableType.LINK]}'."
+            )

--- a/src/diepvries/driving_key_field.py
+++ b/src/diepvries/driving_key_field.py
@@ -14,19 +14,15 @@ class DrivingKeyField:
     defined by a subset of hashkeys.
     """
 
-    def __init__(self, parent_table_name: str, name: str, satellite_name: str):
-        """Instantiate a DrivingKeyField.
+    #: Name of parent table in the database (always a Link).
+    parent_table_name: str
+    #: Column name in the database.
+    name: str
+    #: Name of the satellite where this field represents a driving key.
+    satellite_name: str
 
-        Args:
-            parent_table_name: Name of parent table in the database (always a Link).
-            name: Column name in the database.
-            satellite_name: Name of the satellite where this field
-                represents a driving key.
-        """
-        self.parent_table_name = parent_table_name
-        self.name = name
-        self.satellite_name = satellite_name
-
+    def __post_init__(self):
+        """Validate the driving key."""
         self._validate()
 
     def __str__(self) -> str:

--- a/src/diepvries/driving_key_field.py
+++ b/src/diepvries/driving_key_field.py
@@ -43,16 +43,15 @@ class DrivingKeyField:
         )
 
     def _validate(self):
-        """Validate driving key
+        """Validate driving key.
 
         Perform the following checks:
-        1. Satellite name has a prefix within TABLE_PREFIXES[TableType.SATELLITE]
-        2. Parent table name has a prefix within TABLE_PREFIXES[TableType.LINK]
+        1. Satellite name has a prefix within TABLE_PREFIXES[TableType.SATELLITE].
+        2. Parent table name has a prefix within TABLE_PREFIXES[TableType.LINK].
 
         Raises:
             RuntimeError: If one of the checks fails.
         """
-
         satellite_name_prefix = next(
             split_part for split_part in self.satellite_name.split("_")
         )

--- a/test/test_driving_key_field.py
+++ b/test/test_driving_key_field.py
@@ -1,0 +1,33 @@
+"""Unit test for DrivingKeyField."""
+from diepvries import TableType, TABLE_PREFIXES
+from diepvries.driving_key_field import DrivingKeyField
+
+
+def test_satellite_name_prefix(ls_order_customer_eff_driving_keys: DrivingKeyField):
+    """Assert correctness of satellite table names prefix in list of driving keys
+    ls_order_customer_eff_driving_keys.
+
+    Args:
+        ls_order_customer_eff_driving_keys: ls_order_customer_eff_driving_keys
+        fixture value.
+    """
+    for driving_key in ls_order_customer_eff_driving_keys:
+        table_name_prefix = next(
+            split_part for split_part in driving_key.satellite_name.split("_")
+        )
+        assert table_name_prefix in TABLE_PREFIXES[TableType.SATELLITE]
+
+
+def test_parent_table_name_prefix(ls_order_customer_eff_driving_keys: DrivingKeyField):
+    """Assert correctness of parent table names prefix in list of driving keys
+    ls_order_customer_eff_driving_keys.
+
+    Args:
+        ls_order_customer_eff_driving_keys: ls_order_customer_eff_driving_keys
+        fixture value.
+    """
+    for driving_key in ls_order_customer_eff_driving_keys:
+        table_name_prefix = next(
+            split_part for split_part in driving_key.parent_table_name.split("_")
+        )
+        assert table_name_prefix in TABLE_PREFIXES[TableType.LINK]

--- a/test/test_driving_key_field.py
+++ b/test/test_driving_key_field.py
@@ -1,5 +1,5 @@
 """Unit test for DrivingKeyField."""
-from diepvries import TableType, TABLE_PREFIXES
+from diepvries import TABLE_PREFIXES, TableType
 from diepvries.driving_key_field import DrivingKeyField
 
 

--- a/test/test_driving_key_field.py
+++ b/test/test_driving_key_field.py
@@ -1,33 +1,38 @@
 """Unit test for DrivingKeyField."""
-from diepvries import TABLE_PREFIXES, TableType
+import pytest
 from diepvries.driving_key_field import DrivingKeyField
 
 
-def test_satellite_name_prefix(ls_order_customer_eff_driving_keys: DrivingKeyField):
-    """Assert correctness of satellite table names prefix in list of driving keys
-    ls_order_customer_eff_driving_keys.
-
-    Args:
-        ls_order_customer_eff_driving_keys: ls_order_customer_eff_driving_keys
-        fixture value.
+def test_valid_driving_key():
+    """Check that no errors are raised when instantiating a
+    DrivingKeyField with valid values.
     """
-    for driving_key in ls_order_customer_eff_driving_keys:
-        table_name_prefix = next(
-            split_part for split_part in driving_key.satellite_name.split("_")
-        )
-        assert table_name_prefix in TABLE_PREFIXES[TableType.SATELLITE]
+    DrivingKeyField(
+        name="h_customer_hashkey",
+        parent_table_name="l_order_customer",
+        satellite_name="ls_order_customer_eff",
+    )
 
 
-def test_parent_table_name_prefix(ls_order_customer_eff_driving_keys: DrivingKeyField):
-    """Assert correctness of parent table names prefix in list of driving keys
-    ls_order_customer_eff_driving_keys.
-
-    Args:
-        ls_order_customer_eff_driving_keys: ls_order_customer_eff_driving_keys
-        fixture value.
+def test_invalid_satellite_name():
+    """Check that an `AssertionError` is raised when an invalid
+    satellite_name is provided.
     """
-    for driving_key in ls_order_customer_eff_driving_keys:
-        table_name_prefix = next(
-            split_part for split_part in driving_key.parent_table_name.split("_")
+    with pytest.raises(AssertionError):
+        DrivingKeyField(
+            name="h_customer_hashkey",
+            parent_table_name="l_order_customer",
+            satellite_name="invalid_satellite_name",
         )
-        assert table_name_prefix in TABLE_PREFIXES[TableType.LINK]
+
+
+def test_invalid_parent_table_name():
+    """Check that an `AssertionError` is raised when an invalid
+    parent_table_name is provided.
+    """
+    with pytest.raises(AssertionError):
+        DrivingKeyField(
+            name="h_customer_hashkey",
+            parent_table_name="invalid_parent_table_name",
+            satellite_name="ls_order_customer_eff",
+        )


### PR DESCRIPTION
**Issue**: We noticed an issue with duplicates in the link/eff_sattelite tables when the **incorrect** prefix is given to the table names. 

**Solution**: Add a validation that will fail the process when:
* The prefix of the `satellite_name` is not within `TABLE_PREFIXES[TableType.SATELLITE]`.
* The prefix of the `parent_table_name` is not within `TABLE_PREFIXES[TableType.LINK]`.

**Implementation**: Add a validation method in the instantiation of a driving key.