### PR TITLE
Use load timestamp to improve performance of MERGE query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Add filter to `MERGE` clauses to reduce the number of scanned records.
+
+## [Unreleased]
+### Added
 - Add method `sql_load_scripts_by_group` to `DataVaultLoad`.
 
 ## [0.7.0] - 2023-05-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added
-- Add filter to `MERGE` clauses to reduce the number of scanned records.
+### Changed
+- Add filter to `MERGE` clauses to reduce the number of scanned records. DML queries now consist of two statements, a `SET` and a `MERGE`, instead of just a `MERGE` query.
 
 ## [Unreleased]
 ### Added

--- a/src/diepvries/template_sql/effectivity_satellite_dml.sql
+++ b/src/diepvries/template_sql/effectivity_satellite_dml.sql
@@ -10,7 +10,6 @@ SET min_timestamp = (
                                       AND satellite.{record_end_timestamp_name} = {end_of_time})
                         INNER JOIN {staging_schema}.{staging_table} AS staging
                                    ON ({link_driving_key_condition})
-                                     )
                       );
 
 MERGE INTO {target_schema}.{target_table} AS satellite

--- a/src/diepvries/template_sql/effectivity_satellite_dml.sql
+++ b/src/diepvries/template_sql/effectivity_satellite_dml.sql
@@ -21,7 +21,7 @@ MERGE INTO {target_schema}.{target_table} AS satellite
             INNER JOIN {target_schema}.{target_table} AS satellite
                        ON (l.{hashkey_field} = satellite.{hashkey_field}
                          AND satellite.{record_end_timestamp_name} = {end_of_time})
-          WHERE satellite.r_timestamp>= $min_timestamp
+          WHERE satellite.{record_start_timestamp} >= $min_timestamp
                                    ),
           filtered_effectivity_satellite AS (
           SELECT
@@ -44,7 +44,7 @@ MERGE INTO {target_schema}.{target_table} AS satellite
                              1
                            FROM filtered_effectivity_satellite AS satellite
                            WHERE {satellite_driving_key_condition}
-                             AND satellite.r_timestamp >= staging.r_timestamp
+                             AND satellite.{record_start_timestamp} >= staging.{record_start_timestamp}
                            )
                               ),
           --   Records that will be inserted (don't exist in target table or exist

--- a/src/diepvries/template_sql/effectivity_satellite_dml.sql
+++ b/src/diepvries/template_sql/effectivity_satellite_dml.sql
@@ -3,10 +3,11 @@ SET min_timestamp = (
                         COALESCE(MIN(satellite.{record_start_timestamp}), CURRENT_TIMESTAMP())
                       FROM {target_schema}.{link_table} AS l
                         INNER JOIN {target_schema}.{target_table} AS satellite
-                                   ON (l.{hashkey_field} = satellite.{hashkey_field})
+                                   ON (l.{hashkey_field} = satellite.{hashkey_field}
+                                      AND satellite.{record_end_timestamp_name} = {end_of_time})
                         INNER JOIN {staging_schema}.{staging_table} AS staging
-                                   ON ({satellite_driving_key_condition}
-                                     AND satellite.{record_end_timestamp_name} = {end_of_time})
+                                   ON ({link_driving_key_condition})
+                                     )
                       );
 
 MERGE INTO {target_schema}.{target_table} AS satellite

--- a/src/diepvries/template_sql/effectivity_satellite_dml.sql
+++ b/src/diepvries/template_sql/effectivity_satellite_dml.sql
@@ -3,8 +3,7 @@ SET min_timestamp = (
                         COALESCE(MIN(satellite.{record_start_timestamp}), CURRENT_TIMESTAMP())
                       FROM {target_schema}.{link_table} AS l
                         INNER JOIN {target_schema}.{target_table} AS satellite
-                                   ON (l.{hashkey_field} = satellite.{hashkey_field}
-                                     AND satellite.{record_end_timestamp_name} = {end_of_time})
+                                   ON (l.{hashkey_field} = satellite.{hashkey_field})
                         INNER JOIN {staging_schema}.{staging_table} AS staging
                                    ON ({satellite_driving_key_condition}
                                      AND satellite.{record_end_timestamp_name} = {end_of_time})

--- a/src/diepvries/template_sql/effectivity_satellite_dml.sql
+++ b/src/diepvries/template_sql/effectivity_satellite_dml.sql
@@ -3,7 +3,7 @@
 -- the usage of the recommended clustering key (r_timestamp :: DATE).
 SET min_timestamp = (
                       SELECT
-                        COALESCE(MIN(satellite.{record_start_timestamp}), CURRENT_TIMESTAMP())
+                        COALESCE(MIN(satellite.{record_start_timestamp}), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
                       FROM {target_schema}.{link_table} AS l
                         INNER JOIN {target_schema}.{target_table} AS satellite
                                    ON (l.{hashkey_field} = satellite.{hashkey_field}

--- a/src/diepvries/template_sql/effectivity_satellite_dml.sql
+++ b/src/diepvries/template_sql/effectivity_satellite_dml.sql
@@ -1,6 +1,10 @@
 -- Calculate minimum timestamp that can be affected by the current load.
 -- This timestamp is used in the MERGE statement to reduce the number of records scanned, ensuring
 -- the usage of the recommended clustering key (r_timestamp :: DATE).
+-- If there are no matches between the staging table and the target table, the minimum timestamp is set to the
+-- current timestamp minus 4 hours. The four hours are subtracted as a "safety net" to avoid the insertion of
+-- duplicate records when the first version of a given driving key is being loaded by two processes running in parallel.
+-- This is unlikely to happen, but still better to play it on the safe side.
 SET min_timestamp = (
                       SELECT
                         COALESCE(MIN(satellite.{record_start_timestamp}), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))

--- a/src/diepvries/template_sql/effectivity_satellite_dml.sql
+++ b/src/diepvries/template_sql/effectivity_satellite_dml.sql
@@ -1,3 +1,6 @@
+-- Calculate minimum timestamp that can be affected by the current load.
+-- This timestamp is used in the MERGE statement to reduce the number of records scanned, ensuring
+-- the usage of the recommended clustering key (r_timestamp :: DATE).
 SET min_timestamp = (
                       SELECT
                         COALESCE(MIN(satellite.{record_start_timestamp}), CURRENT_TIMESTAMP())

--- a/src/diepvries/template_sql/hub_link_dml.sql
+++ b/src/diepvries/template_sql/hub_link_dml.sql
@@ -1,6 +1,10 @@
 -- Calculate minimum timestamp that can be affected by the current load.
 -- This timestamp is used in the MERGE statement to reduce the number of records scanned, ensuring
 -- the usage of the recommended clustering key (r_timestamp :: DATE).
+-- If there are no matches between the staging table and the target table, the minimum timestamp is set to the
+-- current timestamp minus 4 hours. The four hours are subtracted as a "safety net" to avoid the insertion of
+-- duplicate records when the first version of a given hashkey is being loaded by two processes running in parallel.
+-- This is unlikely to happen, but still better to play it on the safe side.
 SET min_timestamp = (
                     SELECT
                       COALESCE(MIN(target.{record_start_timestamp}), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))

--- a/src/diepvries/template_sql/hub_link_dml.sql
+++ b/src/diepvries/template_sql/hub_link_dml.sql
@@ -3,7 +3,7 @@
 -- the usage of the recommended clustering key (r_timestamp :: DATE).
 SET min_timestamp = (
                     SELECT
-                      COALESCE(MIN(target.{record_start_timestamp}), CURRENT_TIMESTAMP())
+                      COALESCE(MIN(target.{record_start_timestamp}), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
                     FROM {staging_schema}.{staging_table} AS staging
                       INNER JOIN {target_schema}.{target_table} AS target
                                  ON (staging.{source_hashkey_field} = target.{target_hashkey_field})

--- a/src/diepvries/template_sql/hub_link_dml.sql
+++ b/src/diepvries/template_sql/hub_link_dml.sql
@@ -1,3 +1,11 @@
+SET min_timestamp = (
+                    SELECT
+                      COALESCE(MIN(target.{record_start_timestamp}), CURRENT_TIMESTAMP())
+                    FROM {staging_schema}.{staging_table} AS staging
+                      INNER JOIN {target_schema}.{target_table} AS target
+                                 ON (staging.{source_hashkey_field} = target.{target_hashkey_field})
+                    );
+
 MERGE INTO {target_schema}.{target_table} AS target
   USING (
         SELECT DISTINCT
@@ -5,10 +13,11 @@ MERGE INTO {target_schema}.{target_table} AS target
           -- If multiple sources for the same hashkey are received, their values
           -- are concatenated using a comma.
           LISTAGG(DISTINCT {record_source_field}, ',')
-              WITHIN GROUP (ORDER BY {record_source_field})
-              OVER (PARTITION BY {source_hashkey_field}) AS {record_source_field},
+                  WITHIN GROUP (ORDER BY {record_source_field})
+                  OVER (PARTITION BY {source_hashkey_field}) AS {record_source_field},
           {source_fields}
         FROM {staging_schema}.{staging_table}
-        ) AS staging ON (target.{target_hashkey_field} = staging.{source_hashkey_field})
+        ) AS staging ON (target.{target_hashkey_field} = staging.{source_hashkey_field}
+    AND target.{record_start_timestamp} >= $min_timestamp)
   WHEN NOT MATCHED THEN INSERT ({target_fields})
     VALUES ({staging_source_fields});

--- a/src/diepvries/template_sql/hub_link_dml.sql
+++ b/src/diepvries/template_sql/hub_link_dml.sql
@@ -1,3 +1,6 @@
+-- Calculate minimum timestamp that can be affected by the current load.
+-- This timestamp is used in the MERGE statement to reduce the number of records scanned, ensuring
+-- the usage of the recommended clustering key (r_timestamp :: DATE).
 SET min_timestamp = (
                     SELECT
                       COALESCE(MIN(target.{record_start_timestamp}), CURRENT_TIMESTAMP())

--- a/src/diepvries/template_sql/satellite_dml.sql
+++ b/src/diepvries/template_sql/satellite_dml.sql
@@ -1,6 +1,10 @@
 -- Calculate minimum timestamp that can be affected by the current load.
 -- This timestamp is used in the MERGE statement to reduce the number of records scanned, ensuring
 -- the usage of the recommended clustering key (r_timestamp :: DATE).
+-- If there are no matches between the staging table and the target table, the minimum timestamp is set to the
+-- current timestamp minus 4 hours. The four hours are subtracted as a "safety net" to avoid the insertion of
+-- duplicate records when the first version of a given hashkey is being loaded by two processes running in parallel.
+-- This is unlikely to happen, but still better to play it on the safe side.
 SET min_timestamp = (
                     SELECT
                       COALESCE(MIN(satellite.{record_start_timestamp}), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))

--- a/src/diepvries/template_sql/satellite_dml.sql
+++ b/src/diepvries/template_sql/satellite_dml.sql
@@ -3,7 +3,7 @@
 -- the usage of the recommended clustering key (r_timestamp :: DATE).
 SET min_timestamp = (
                     SELECT
-                      COALESCE(MIN(satellite.{record_start_timestamp}), CURRENT_TIMESTAMP())
+                      COALESCE(MIN(satellite.{record_start_timestamp}), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
                     FROM {staging_schema}.{staging_table} AS staging
                       INNER JOIN {target_schema}.{target_table} AS satellite
                                  ON (satellite.{hashkey_field} = staging.{hashkey_field}

--- a/src/diepvries/template_sql/satellite_dml.sql
+++ b/src/diepvries/template_sql/satellite_dml.sql
@@ -1,3 +1,6 @@
+-- Calculate minimum timestamp that can be affected by the current load.
+-- This timestamp is used in the MERGE statement to reduce the number of records scanned, ensuring
+-- the usage of the recommended clustering key (r_timestamp :: DATE).
 SET min_timestamp = (
                     SELECT
                       COALESCE(MIN(satellite.{record_start_timestamp}), CURRENT_TIMESTAMP())

--- a/test/sql/expected_result_data_vault_load.sql
+++ b/test/sql/expected_result_data_vault_load.sql
@@ -246,7 +246,6 @@ SET min_timestamp = (
                                       AND satellite.r_timestamp_end = CAST('9999-12-31T00:00:00.000000Z' AS TIMESTAMP))
                         INNER JOIN dv_stg.orders_20190806_000000 AS staging
                                    ON (l.h_customer_hashkey = staging.h_customer_hashkey)
-                                     )
                       );
 
 MERGE INTO dv.ls_order_customer_eff AS satellite
@@ -357,7 +356,6 @@ SET min_timestamp = (
                                       AND satellite.r_timestamp_end = CAST('9999-12-31T00:00:00.000000Z' AS TIMESTAMP))
                         INNER JOIN dv_stg.orders_20190806_000000 AS staging
                                    ON (l.h_customer_role_playing_hashkey = staging.h_customer_role_playing_hashkey)
-                                     )
                       );
 
 MERGE INTO dv.ls_order_customer_role_playing_eff AS satellite

--- a/test/sql/expected_result_data_vault_load.sql
+++ b/test/sql/expected_result_data_vault_load.sql
@@ -8,7 +8,7 @@ CREATE OR REPLACE TABLE dv_stg.orders_20190806_000000
 -- the usage of the recommended clustering key (r_timestamp :: DATE).
 SET min_timestamp = (
                     SELECT
-                      COALESCE(MIN(target.r_timestamp), CURRENT_TIMESTAMP())
+                      COALESCE(MIN(target.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
                     FROM dv_stg.orders_20190806_000000 AS staging
                       INNER JOIN dv.h_customer AS target
                                  ON (staging.h_customer_hashkey = target.h_customer_hashkey)
@@ -35,7 +35,7 @@ MERGE INTO dv.h_customer AS target
 -- the usage of the recommended clustering key (r_timestamp :: DATE).
 SET min_timestamp = (
                     SELECT
-                      COALESCE(MIN(target.r_timestamp), CURRENT_TIMESTAMP())
+                      COALESCE(MIN(target.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
                     FROM dv_stg.orders_20190806_000000 AS staging
                       INNER JOIN dv.h_customer AS target
                                  ON (staging.h_customer_role_playing_hashkey = target.h_customer_hashkey)
@@ -62,7 +62,7 @@ MERGE INTO dv.h_customer AS target
 -- the usage of the recommended clustering key (r_timestamp :: DATE).
 SET min_timestamp = (
                     SELECT
-                      COALESCE(MIN(target.r_timestamp), CURRENT_TIMESTAMP())
+                      COALESCE(MIN(target.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
                     FROM dv_stg.orders_20190806_000000 AS staging
                       INNER JOIN dv.h_order AS target
                                  ON (staging.h_order_hashkey = target.h_order_hashkey)
@@ -89,7 +89,7 @@ MERGE INTO dv.h_order AS target
 -- the usage of the recommended clustering key (r_timestamp :: DATE).
 SET min_timestamp = (
                     SELECT
-                      COALESCE(MIN(target.r_timestamp), CURRENT_TIMESTAMP())
+                      COALESCE(MIN(target.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
                     FROM dv_stg.orders_20190806_000000 AS staging
                       INNER JOIN dv.l_order_customer AS target
                                  ON (staging.l_order_customer_hashkey = target.l_order_customer_hashkey)
@@ -116,7 +116,7 @@ MERGE INTO dv.l_order_customer AS target
 -- the usage of the recommended clustering key (r_timestamp :: DATE).
 SET min_timestamp = (
                     SELECT
-                      COALESCE(MIN(target.r_timestamp), CURRENT_TIMESTAMP())
+                      COALESCE(MIN(target.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
                     FROM dv_stg.orders_20190806_000000 AS staging
                       INNER JOIN dv.l_order_customer_role_playing AS target
                                  ON (staging.l_order_customer_role_playing_hashkey = target.l_order_customer_role_playing_hashkey)
@@ -143,7 +143,7 @@ MERGE INTO dv.l_order_customer_role_playing AS target
 -- the usage of the recommended clustering key (r_timestamp :: DATE).
 SET min_timestamp = (
                     SELECT
-                      COALESCE(MIN(satellite.r_timestamp), CURRENT_TIMESTAMP())
+                      COALESCE(MIN(satellite.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
                     FROM dv_stg.orders_20190806_000000 AS staging
                       INNER JOIN dv.hs_customer AS satellite
                                  ON (satellite.h_customer_hashkey = staging.h_customer_hashkey
@@ -239,7 +239,7 @@ MERGE INTO dv.hs_customer AS satellite
 -- the usage of the recommended clustering key (r_timestamp :: DATE).
 SET min_timestamp = (
                       SELECT
-                        COALESCE(MIN(satellite.r_timestamp), CURRENT_TIMESTAMP())
+                        COALESCE(MIN(satellite.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
                       FROM dv.l_order_customer AS l
                         INNER JOIN dv.ls_order_customer_eff AS satellite
                                    ON (l.l_order_customer_hashkey = satellite.l_order_customer_hashkey
@@ -349,7 +349,7 @@ MERGE INTO dv.ls_order_customer_eff AS satellite
 -- the usage of the recommended clustering key (r_timestamp :: DATE).
 SET min_timestamp = (
                       SELECT
-                        COALESCE(MIN(satellite.r_timestamp), CURRENT_TIMESTAMP())
+                        COALESCE(MIN(satellite.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
                       FROM dv.l_order_customer_role_playing AS l
                         INNER JOIN dv.ls_order_customer_role_playing_eff AS satellite
                                    ON (l.l_order_customer_role_playing_hashkey = satellite.l_order_customer_role_playing_hashkey

--- a/test/sql/expected_result_data_vault_load.sql
+++ b/test/sql/expected_result_data_vault_load.sql
@@ -6,6 +6,10 @@ CREATE OR REPLACE TABLE dv_stg.orders_20190806_000000
 -- Calculate minimum timestamp that can be affected by the current load.
 -- This timestamp is used in the MERGE statement to reduce the number of records scanned, ensuring
 -- the usage of the recommended clustering key (r_timestamp :: DATE).
+-- If there are no matches between the staging table and the target table, the minimum timestamp is set to the
+-- current timestamp minus 4 hours. The four hours are subtracted as a "safety net" to avoid the insertion of
+-- duplicate records when the first version of a given hashkey is being loaded by two processes running in parallel.
+-- This is unlikely to happen, but still better to play it on the safe side.
 SET min_timestamp = (
                     SELECT
                       COALESCE(MIN(target.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
@@ -33,6 +37,10 @@ MERGE INTO dv.h_customer AS target
 -- Calculate minimum timestamp that can be affected by the current load.
 -- This timestamp is used in the MERGE statement to reduce the number of records scanned, ensuring
 -- the usage of the recommended clustering key (r_timestamp :: DATE).
+-- If there are no matches between the staging table and the target table, the minimum timestamp is set to the
+-- current timestamp minus 4 hours. The four hours are subtracted as a "safety net" to avoid the insertion of
+-- duplicate records when the first version of a given hashkey is being loaded by two processes running in parallel.
+-- This is unlikely to happen, but still better to play it on the safe side.
 SET min_timestamp = (
                     SELECT
                       COALESCE(MIN(target.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
@@ -60,6 +68,10 @@ MERGE INTO dv.h_customer AS target
 -- Calculate minimum timestamp that can be affected by the current load.
 -- This timestamp is used in the MERGE statement to reduce the number of records scanned, ensuring
 -- the usage of the recommended clustering key (r_timestamp :: DATE).
+-- If there are no matches between the staging table and the target table, the minimum timestamp is set to the
+-- current timestamp minus 4 hours. The four hours are subtracted as a "safety net" to avoid the insertion of
+-- duplicate records when the first version of a given hashkey is being loaded by two processes running in parallel.
+-- This is unlikely to happen, but still better to play it on the safe side.
 SET min_timestamp = (
                     SELECT
                       COALESCE(MIN(target.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
@@ -87,6 +99,10 @@ MERGE INTO dv.h_order AS target
 -- Calculate minimum timestamp that can be affected by the current load.
 -- This timestamp is used in the MERGE statement to reduce the number of records scanned, ensuring
 -- the usage of the recommended clustering key (r_timestamp :: DATE).
+-- If there are no matches between the staging table and the target table, the minimum timestamp is set to the
+-- current timestamp minus 4 hours. The four hours are subtracted as a "safety net" to avoid the insertion of
+-- duplicate records when the first version of a given hashkey is being loaded by two processes running in parallel.
+-- This is unlikely to happen, but still better to play it on the safe side.
 SET min_timestamp = (
                     SELECT
                       COALESCE(MIN(target.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
@@ -114,6 +130,10 @@ MERGE INTO dv.l_order_customer AS target
 -- Calculate minimum timestamp that can be affected by the current load.
 -- This timestamp is used in the MERGE statement to reduce the number of records scanned, ensuring
 -- the usage of the recommended clustering key (r_timestamp :: DATE).
+-- If there are no matches between the staging table and the target table, the minimum timestamp is set to the
+-- current timestamp minus 4 hours. The four hours are subtracted as a "safety net" to avoid the insertion of
+-- duplicate records when the first version of a given hashkey is being loaded by two processes running in parallel.
+-- This is unlikely to happen, but still better to play it on the safe side.
 SET min_timestamp = (
                     SELECT
                       COALESCE(MIN(target.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
@@ -141,6 +161,10 @@ MERGE INTO dv.l_order_customer_role_playing AS target
 -- Calculate minimum timestamp that can be affected by the current load.
 -- This timestamp is used in the MERGE statement to reduce the number of records scanned, ensuring
 -- the usage of the recommended clustering key (r_timestamp :: DATE).
+-- If there are no matches between the staging table and the target table, the minimum timestamp is set to the
+-- current timestamp minus 4 hours. The four hours are subtracted as a "safety net" to avoid the insertion of
+-- duplicate records when the first version of a given hashkey is being loaded by two processes running in parallel.
+-- This is unlikely to happen, but still better to play it on the safe side.
 SET min_timestamp = (
                     SELECT
                       COALESCE(MIN(satellite.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
@@ -237,6 +261,10 @@ MERGE INTO dv.hs_customer AS satellite
 -- Calculate minimum timestamp that can be affected by the current load.
 -- This timestamp is used in the MERGE statement to reduce the number of records scanned, ensuring
 -- the usage of the recommended clustering key (r_timestamp :: DATE).
+-- If there are no matches between the staging table and the target table, the minimum timestamp is set to the
+-- current timestamp minus 4 hours. The four hours are subtracted as a "safety net" to avoid the insertion of
+-- duplicate records when the first version of a given driving key is being loaded by two processes running in parallel.
+-- This is unlikely to happen, but still better to play it on the safe side.
 SET min_timestamp = (
                       SELECT
                         COALESCE(MIN(satellite.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
@@ -347,6 +375,10 @@ MERGE INTO dv.ls_order_customer_eff AS satellite
 -- Calculate minimum timestamp that can be affected by the current load.
 -- This timestamp is used in the MERGE statement to reduce the number of records scanned, ensuring
 -- the usage of the recommended clustering key (r_timestamp :: DATE).
+-- If there are no matches between the staging table and the target table, the minimum timestamp is set to the
+-- current timestamp minus 4 hours. The four hours are subtracted as a "safety net" to avoid the insertion of
+-- duplicate records when the first version of a given driving key is being loaded by two processes running in parallel.
+-- This is unlikely to happen, but still better to play it on the safe side.
 SET min_timestamp = (
                       SELECT
                         COALESCE(MIN(satellite.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))

--- a/test/sql/expected_result_effectivity_satellite.sql
+++ b/test/sql/expected_result_effectivity_satellite.sql
@@ -3,7 +3,7 @@
 -- the usage of the recommended clustering key (r_timestamp :: DATE).
 SET min_timestamp = (
                       SELECT
-                        COALESCE(MIN(satellite.r_timestamp), CURRENT_TIMESTAMP())
+                        COALESCE(MIN(satellite.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
                       FROM dv.l_order_customer AS l
                         INNER JOIN dv.ls_order_customer_eff AS satellite
                                    ON (l.l_order_customer_hashkey = satellite.l_order_customer_hashkey

--- a/test/sql/expected_result_effectivity_satellite.sql
+++ b/test/sql/expected_result_effectivity_satellite.sql
@@ -1,6 +1,10 @@
 -- Calculate minimum timestamp that can be affected by the current load.
 -- This timestamp is used in the MERGE statement to reduce the number of records scanned, ensuring
 -- the usage of the recommended clustering key (r_timestamp :: DATE).
+-- If there are no matches between the staging table and the target table, the minimum timestamp is set to the
+-- current timestamp minus 4 hours. The four hours are subtracted as a "safety net" to avoid the insertion of
+-- duplicate records when the first version of a given driving key is being loaded by two processes running in parallel.
+-- This is unlikely to happen, but still better to play it on the safe side.
 SET min_timestamp = (
                       SELECT
                         COALESCE(MIN(satellite.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))

--- a/test/sql/expected_result_effectivity_satellite.sql
+++ b/test/sql/expected_result_effectivity_satellite.sql
@@ -10,7 +10,6 @@ SET min_timestamp = (
                                       AND satellite.r_timestamp_end = CAST('9999-12-31T00:00:00.000000Z' AS TIMESTAMP))
                         INNER JOIN dv_stg.orders_20190806_000000 AS staging
                                    ON (l.h_customer_hashkey = staging.h_customer_hashkey)
-                                     )
                       );
 
 MERGE INTO dv.ls_order_customer_eff AS satellite

--- a/test/sql/expected_result_hub.sql
+++ b/test/sql/expected_result_hub.sql
@@ -1,6 +1,10 @@
 -- Calculate minimum timestamp that can be affected by the current load.
 -- This timestamp is used in the MERGE statement to reduce the number of records scanned, ensuring
 -- the usage of the recommended clustering key (r_timestamp :: DATE).
+-- If there are no matches between the staging table and the target table, the minimum timestamp is set to the
+-- current timestamp minus 4 hours. The four hours are subtracted as a "safety net" to avoid the insertion of
+-- duplicate records when the first version of a given hashkey is being loaded by two processes running in parallel.
+-- This is unlikely to happen, but still better to play it on the safe side.
 SET min_timestamp = (
                     SELECT
                       COALESCE(MIN(target.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))

--- a/test/sql/expected_result_hub.sql
+++ b/test/sql/expected_result_hub.sql
@@ -3,7 +3,7 @@
 -- the usage of the recommended clustering key (r_timestamp :: DATE).
 SET min_timestamp = (
                     SELECT
-                      COALESCE(MIN(target.r_timestamp), CURRENT_TIMESTAMP())
+                      COALESCE(MIN(target.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
                     FROM dv_stg.orders_20190806_000000 AS staging
                       INNER JOIN dv.h_customer AS target
                                  ON (staging.h_customer_hashkey = target.h_customer_hashkey)

--- a/test/sql/expected_result_hub.sql
+++ b/test/sql/expected_result_hub.sql
@@ -1,3 +1,14 @@
+-- Calculate minimum timestamp that can be affected by the current load.
+-- This timestamp is used in the MERGE statement to reduce the number of records scanned, ensuring
+-- the usage of the recommended clustering key (r_timestamp :: DATE).
+SET min_timestamp = (
+                    SELECT
+                      COALESCE(MIN(target.r_timestamp), CURRENT_TIMESTAMP())
+                    FROM dv_stg.orders_20190806_000000 AS staging
+                      INNER JOIN dv.h_customer AS target
+                                 ON (staging.h_customer_hashkey = target.h_customer_hashkey)
+                    );
+
 MERGE INTO dv.h_customer AS target
   USING (
         SELECT DISTINCT
@@ -5,10 +16,11 @@ MERGE INTO dv.h_customer AS target
           -- If multiple sources for the same hashkey are received, their values
           -- are concatenated using a comma.
           LISTAGG(DISTINCT r_source, ',')
-              WITHIN GROUP (ORDER BY r_source)
-              OVER (PARTITION BY h_customer_hashkey) AS r_source,
+                  WITHIN GROUP (ORDER BY r_source)
+                  OVER (PARTITION BY h_customer_hashkey) AS r_source,
           r_timestamp, customer_id
         FROM dv_stg.orders_20190806_000000
-        ) AS staging ON (target.h_customer_hashkey = staging.h_customer_hashkey)
+        ) AS staging ON (target.h_customer_hashkey = staging.h_customer_hashkey
+    AND target.r_timestamp >= $min_timestamp)
   WHEN NOT MATCHED THEN INSERT (h_customer_hashkey, r_timestamp, r_source, customer_id)
     VALUES (staging.h_customer_hashkey, staging.r_timestamp, staging.r_source, staging.customer_id);

--- a/test/sql/expected_result_link.sql
+++ b/test/sql/expected_result_link.sql
@@ -3,7 +3,7 @@
 -- the usage of the recommended clustering key (r_timestamp :: DATE).
 SET min_timestamp = (
                     SELECT
-                      COALESCE(MIN(target.r_timestamp), CURRENT_TIMESTAMP())
+                      COALESCE(MIN(target.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
                     FROM dv_stg.orders_20190806_000000 AS staging
                       INNER JOIN dv.l_order_customer AS target
                                  ON (staging.l_order_customer_hashkey = target.l_order_customer_hashkey)

--- a/test/sql/expected_result_link.sql
+++ b/test/sql/expected_result_link.sql
@@ -1,6 +1,10 @@
 -- Calculate minimum timestamp that can be affected by the current load.
 -- This timestamp is used in the MERGE statement to reduce the number of records scanned, ensuring
 -- the usage of the recommended clustering key (r_timestamp :: DATE).
+-- If there are no matches between the staging table and the target table, the minimum timestamp is set to the
+-- current timestamp minus 4 hours. The four hours are subtracted as a "safety net" to avoid the insertion of
+-- duplicate records when the first version of a given hashkey is being loaded by two processes running in parallel.
+-- This is unlikely to happen, but still better to play it on the safe side.
 SET min_timestamp = (
                     SELECT
                       COALESCE(MIN(target.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))

--- a/test/sql/expected_result_link.sql
+++ b/test/sql/expected_result_link.sql
@@ -1,3 +1,14 @@
+-- Calculate minimum timestamp that can be affected by the current load.
+-- This timestamp is used in the MERGE statement to reduce the number of records scanned, ensuring
+-- the usage of the recommended clustering key (r_timestamp :: DATE).
+SET min_timestamp = (
+                    SELECT
+                      COALESCE(MIN(target.r_timestamp), CURRENT_TIMESTAMP())
+                    FROM dv_stg.orders_20190806_000000 AS staging
+                      INNER JOIN dv.l_order_customer AS target
+                                 ON (staging.l_order_customer_hashkey = target.l_order_customer_hashkey)
+                    );
+
 MERGE INTO dv.l_order_customer AS target
   USING (
         SELECT DISTINCT
@@ -5,10 +16,11 @@ MERGE INTO dv.l_order_customer AS target
           -- If multiple sources for the same hashkey are received, their values
           -- are concatenated using a comma.
           LISTAGG(DISTINCT r_source, ',')
-              WITHIN GROUP (ORDER BY r_source)
-              OVER (PARTITION BY l_order_customer_hashkey) AS r_source,
+                  WITHIN GROUP (ORDER BY r_source)
+                  OVER (PARTITION BY l_order_customer_hashkey) AS r_source,
           h_order_hashkey, h_customer_hashkey, order_id, customer_id, ck_test_string, ck_test_timestamp, r_timestamp
         FROM dv_stg.orders_20190806_000000
-        ) AS staging ON (target.l_order_customer_hashkey = staging.l_order_customer_hashkey)
+        ) AS staging ON (target.l_order_customer_hashkey = staging.l_order_customer_hashkey
+    AND target.r_timestamp >= $min_timestamp)
   WHEN NOT MATCHED THEN INSERT (l_order_customer_hashkey, h_order_hashkey, h_customer_hashkey, order_id, customer_id, ck_test_string, ck_test_timestamp, r_timestamp, r_source)
     VALUES (staging.l_order_customer_hashkey, staging.h_order_hashkey, staging.h_customer_hashkey, staging.order_id, staging.customer_id, staging.ck_test_string, staging.ck_test_timestamp, staging.r_timestamp, staging.r_source);

--- a/test/sql/expected_result_role_playing_hub.sql
+++ b/test/sql/expected_result_role_playing_hub.sql
@@ -1,3 +1,14 @@
+-- Calculate minimum timestamp that can be affected by the current load.
+-- This timestamp is used in the MERGE statement to reduce the number of records scanned, ensuring
+-- the usage of the recommended clustering key (r_timestamp :: DATE).
+SET min_timestamp = (
+                    SELECT
+                      COALESCE(MIN(target.r_timestamp), CURRENT_TIMESTAMP())
+                    FROM dv_stg.orders_20190806_000000 AS staging
+                      INNER JOIN dv.h_customer AS target
+                                 ON (staging.h_customer_role_playing_hashkey = target.h_customer_hashkey)
+                    );
+
 MERGE INTO dv.h_customer AS target
   USING (
         SELECT DISTINCT
@@ -5,10 +16,11 @@ MERGE INTO dv.h_customer AS target
           -- If multiple sources for the same hashkey are received, their values
           -- are concatenated using a comma.
           LISTAGG(DISTINCT r_source, ',')
-              WITHIN GROUP (ORDER BY r_source)
-              OVER (PARTITION BY h_customer_role_playing_hashkey) AS r_source,
+                  WITHIN GROUP (ORDER BY r_source)
+                  OVER (PARTITION BY h_customer_role_playing_hashkey) AS r_source,
           r_timestamp, customer_role_playing_id
         FROM dv_stg.orders_20190806_000000
-        ) AS staging ON (target.h_customer_hashkey = staging.h_customer_role_playing_hashkey)
+        ) AS staging ON (target.h_customer_hashkey = staging.h_customer_role_playing_hashkey
+    AND target.r_timestamp >= $min_timestamp)
   WHEN NOT MATCHED THEN INSERT (h_customer_hashkey, r_timestamp, r_source, customer_id)
     VALUES (staging.h_customer_role_playing_hashkey, staging.r_timestamp, staging.r_source, staging.customer_role_playing_id);

--- a/test/sql/expected_result_role_playing_hub.sql
+++ b/test/sql/expected_result_role_playing_hub.sql
@@ -1,6 +1,10 @@
 -- Calculate minimum timestamp that can be affected by the current load.
 -- This timestamp is used in the MERGE statement to reduce the number of records scanned, ensuring
 -- the usage of the recommended clustering key (r_timestamp :: DATE).
+-- If there are no matches between the staging table and the target table, the minimum timestamp is set to the
+-- current timestamp minus 4 hours. The four hours are subtracted as a "safety net" to avoid the insertion of
+-- duplicate records when the first version of a given hashkey is being loaded by two processes running in parallel.
+-- This is unlikely to happen, but still better to play it on the safe side.
 SET min_timestamp = (
                     SELECT
                       COALESCE(MIN(target.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))

--- a/test/sql/expected_result_role_playing_hub.sql
+++ b/test/sql/expected_result_role_playing_hub.sql
@@ -3,7 +3,7 @@
 -- the usage of the recommended clustering key (r_timestamp :: DATE).
 SET min_timestamp = (
                     SELECT
-                      COALESCE(MIN(target.r_timestamp), CURRENT_TIMESTAMP())
+                      COALESCE(MIN(target.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
                     FROM dv_stg.orders_20190806_000000 AS staging
                       INNER JOIN dv.h_customer AS target
                                  ON (staging.h_customer_role_playing_hashkey = target.h_customer_hashkey)

--- a/test/sql/expected_result_satellite.sql
+++ b/test/sql/expected_result_satellite.sql
@@ -3,7 +3,7 @@
 -- the usage of the recommended clustering key (r_timestamp :: DATE).
 SET min_timestamp = (
                     SELECT
-                      COALESCE(MIN(satellite.r_timestamp), CURRENT_TIMESTAMP())
+                      COALESCE(MIN(satellite.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
                     FROM dv_stg.orders_20190806_000000 AS staging
                       INNER JOIN dv.hs_customer AS satellite
                                  ON (satellite.h_customer_hashkey = staging.h_customer_hashkey

--- a/test/sql/expected_result_satellite.sql
+++ b/test/sql/expected_result_satellite.sql
@@ -1,6 +1,10 @@
 -- Calculate minimum timestamp that can be affected by the current load.
 -- This timestamp is used in the MERGE statement to reduce the number of records scanned, ensuring
 -- the usage of the recommended clustering key (r_timestamp :: DATE).
+-- If there are no matches between the staging table and the target table, the minimum timestamp is set to the
+-- current timestamp minus 4 hours. The four hours are subtracted as a "safety net" to avoid the insertion of
+-- duplicate records when the first version of a given hashkey is being loaded by two processes running in parallel.
+-- This is unlikely to happen, but still better to play it on the safe side.
 SET min_timestamp = (
                     SELECT
                       COALESCE(MIN(satellite.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))

--- a/test/test_data_vault_load.py
+++ b/test/test_data_vault_load.py
@@ -3,6 +3,11 @@
 from pathlib import Path
 
 from diepvries.data_vault_load import DataVaultLoad
+from diepvries.effectivity_satellite import EffectivitySatellite
+from diepvries.hub import Hub
+from diepvries.link import Link
+from diepvries.role_playing_hub import RolePlayingHub
+from diepvries.satellite import Satellite
 
 
 def test_staging_table_sql(test_path: Path, data_vault_load: DataVaultLoad):
@@ -29,7 +34,18 @@ def test_data_vault_load_sql(test_path: Path, data_vault_load: DataVaultLoad):
     assert "\n".join(data_vault_load.sql_load_script) == expected_result
 
 
-def test_data_vault_load_sql_by_group(test_path: Path, data_vault_load: DataVaultLoad):
+def test_data_vault_load_sql_by_group(
+    test_path: Path,
+    data_vault_load: DataVaultLoad,
+    h_customer: Hub,
+    h_customer_role_playing: RolePlayingHub,
+    h_order: Hub,
+    l_order_customer: Link,
+    l_order_customer_role_playing: Link,
+    hs_customer: Satellite,
+    ls_order_customer_eff: EffectivitySatellite,
+    ls_order_customer_role_playing_eff: EffectivitySatellite,
+):
     """Assert correctness of a full DataVault load grouped by execution order.
 
     Args:
@@ -39,18 +55,18 @@ def test_data_vault_load_sql_by_group(test_path: Path, data_vault_load: DataVaul
     groups = data_vault_load.sql_load_scripts_by_group
 
     assert len(groups[0]) == 1  # staging table
-    assert groups[0][0].startswith("CREATE OR REPLACE TABLE dv_stg.orders_")
+    assert groups[0][0] == data_vault_load.staging_create_sql_statement
 
     assert len(groups[1]) == 3  # hubs
-    assert groups[1][0].startswith("MERGE INTO dv.h_customer")
-    assert groups[1][1].startswith("MERGE INTO dv.h_customer")
-    assert groups[1][2].startswith("MERGE INTO dv.h_order")
+    assert groups[1][0] == h_customer.sql_load_statement
+    assert groups[1][1] == h_customer_role_playing.sql_load_statement
+    assert groups[1][2] == h_order.sql_load_statement
 
     assert len(groups[2]) == 2  # links
-    assert groups[2][0].startswith("MERGE INTO dv.l_order_customer")
-    assert groups[2][1].startswith("MERGE INTO dv.l_order_customer_role_playing")
+    assert groups[2][0] == l_order_customer.sql_load_statement
+    assert groups[2][1] == l_order_customer_role_playing.sql_load_statement
 
     assert len(groups[3]) == 3  # satellites
-    assert groups[3][0].startswith("MERGE INTO dv.hs_customer")
-    assert groups[3][1].startswith("MERGE INTO dv.ls_order_customer")
-    assert groups[3][2].startswith("MERGE INTO dv.ls_order_customer_role_playing_eff")
+    assert groups[3][0] == hs_customer.sql_load_statement
+    assert groups[3][1] == ls_order_customer_eff.sql_load_statement
+    assert groups[3][2] == ls_order_customer_role_playing_eff.sql_load_statement

--- a/test/test_driving_key_field.py
+++ b/test/test_driving_key_field.py
@@ -1,5 +1,6 @@
 """Unit test for DrivingKeyField."""
 import pytest
+
 from diepvries.driving_key_field import DrivingKeyField
 
 


### PR DESCRIPTION
The purpose of this PR is to ensure the loading statements of data vault tables scan the least amount of records possible by:
- Calculate the minimum timestamp that can be affected by a given load
- Use this timestamp to filter out the target table in the `MERGE` `ON` clause, ensuring the number of records scanned is the minimum possible.

This strategy is specially efficient for tables that are clustered by `r_timestamp` (or even better by `r_timestamp :: DATE`).