### PR TITLE
Add option to retrieve SQL load scripts grouped by execution order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add method `sql_load_scripts_by_group` to `DataVaultLoad`.
 
 ## [0.7.0] - 2023-05-26
 ### Added

--- a/test/test_data_vault_load.py
+++ b/test/test_data_vault_load.py
@@ -27,3 +27,30 @@ def test_data_vault_load_sql(test_path: Path, data_vault_load: DataVaultLoad):
         test_path / "sql" / "expected_result_data_vault_load.sql"
     ).read_text()
     assert "\n".join(data_vault_load.sql_load_script) == expected_result
+
+
+def test_data_vault_load_sql_by_group(test_path: Path, data_vault_load: DataVaultLoad):
+    """Assert correctness of a full DataVault load grouped by execution order.
+
+    Args:
+        test_path: Test path fixture value.
+        data_vault_load: Data vault load fixture value.
+    """
+    groups = data_vault_load.sql_load_scripts_by_group
+
+    assert len(groups[0]) == 1  # staging table
+    assert groups[0][0].startswith("CREATE OR REPLACE TABLE dv_stg.orders_")
+
+    assert len(groups[1]) == 3  # hubs
+    assert groups[1][0].startswith("MERGE INTO dv.h_customer")
+    assert groups[1][1].startswith("MERGE INTO dv.h_customer")
+    assert groups[1][2].startswith("MERGE INTO dv.h_order")
+
+    assert len(groups[2]) == 2  # links
+    assert groups[2][0].startswith("MERGE INTO dv.l_order_customer")
+    assert groups[2][1].startswith("MERGE INTO dv.l_order_customer_role_playing")
+
+    assert len(groups[3]) == 3  # satellites
+    assert groups[3][0].startswith("MERGE INTO dv.hs_customer")
+    assert groups[3][1].startswith("MERGE INTO dv.ls_order_customer")
+    assert groups[3][2].startswith("MERGE INTO dv.ls_order_customer_role_playing_eff")


### PR DESCRIPTION
Retrieving SQL scripts as groups allows to run scripts within the same group in parallel, therefore speeding up data vault loads.