### PR TITLE
Go back 4 hours in the calculation of minimum timestamp to avoid issues in concurrent loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Go back 4 hours in the calculation of minimum record timestamp to avoid issues in concurrent loads.
+
 ## [0.9.0] - 2023-09-04
 ### Changed
 - Add extra filter on the effectivity satellite's query to reduce the number of scanned

--- a/src/diepvries/template_sql/effectivity_satellite_dml.sql
+++ b/src/diepvries/template_sql/effectivity_satellite_dml.sql
@@ -7,7 +7,7 @@
 -- This is unlikely to happen, but still better to play it on the safe side.
 SET min_timestamp_link = (
                          SELECT
-                           COALESCE(MIN(l.{record_start_timestamp}), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
+                           DATEADD(HOUR, -4, COALESCE(MIN(l.{record_start_timestamp}), CURRENT_TIMESTAMP()))
                          FROM {target_schema}.{link_table} AS l
                            INNER JOIN {staging_schema}.{staging_table} AS staging
                                       ON ({link_driving_key_condition})
@@ -15,8 +15,7 @@ SET min_timestamp_link = (
 
 SET min_timestamp_satellite = (
                               SELECT
-                                COALESCE(MIN(satellite.{record_start_timestamp}),
-                                         DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
+                                DATEADD(HOUR, -4, COALESCE(MIN(satellite.{record_start_timestamp}), CURRENT_TIMESTAMP()))
                               FROM {target_schema}.{link_table} AS l
                                 INNER JOIN {target_schema}.{target_table} AS satellite
                                            ON (l.{hashkey_field} = satellite.{hashkey_field}

--- a/src/diepvries/template_sql/hub_link_dml.sql
+++ b/src/diepvries/template_sql/hub_link_dml.sql
@@ -7,7 +7,7 @@
 -- This is unlikely to happen, but still better to play it on the safe side.
 SET min_timestamp = (
                     SELECT
-                      COALESCE(MIN(target.{record_start_timestamp}), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
+                      DATEADD(HOUR, -4, COALESCE(MIN(target.{record_start_timestamp}), CURRENT_TIMESTAMP()))
                     FROM {staging_schema}.{staging_table} AS staging
                       INNER JOIN {target_schema}.{target_table} AS target
                                  ON (staging.{source_hashkey_field} = target.{target_hashkey_field})

--- a/src/diepvries/template_sql/satellite_dml.sql
+++ b/src/diepvries/template_sql/satellite_dml.sql
@@ -7,7 +7,7 @@
 -- This is unlikely to happen, but still better to play it on the safe side.
 SET min_timestamp = (
                     SELECT
-                      COALESCE(MIN(satellite.{record_start_timestamp}), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
+                      DATEADD(HOUR, -4, COALESCE(MIN(satellite.{record_start_timestamp}), CURRENT_TIMESTAMP()))
                     FROM {staging_schema}.{staging_table} AS staging
                       INNER JOIN {target_schema}.{target_table} AS satellite
                                  ON (satellite.{hashkey_field} = staging.{hashkey_field}

--- a/test/sql/expected_result_data_vault_load.sql
+++ b/test/sql/expected_result_data_vault_load.sql
@@ -167,7 +167,7 @@ MERGE INTO dv.l_order_customer_role_playing AS target
 -- This is unlikely to happen, but still better to play it on the safe side.
 SET min_timestamp = (
                     SELECT
-                      COALESCE(MIN(satellite.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
+                      DATEADD(HOUR, -4, COALESCE(MIN(satellite.r_timestamp), CURRENT_TIMESTAMP()))
                     FROM dv_stg.orders_20190806_000000 AS staging
                       INNER JOIN dv.hs_customer AS satellite
                                  ON (satellite.h_customer_hashkey = staging.h_customer_hashkey
@@ -275,7 +275,7 @@ SET min_timestamp_link = (
 
 SET min_timestamp_satellite = (
                               SELECT
-                                DATEADD(HOUR, -4, COALESCE(MIN(satellite.r_timestamp), CURRENT_TIMESTAMP()))     
+                                DATEADD(HOUR, -4, COALESCE(MIN(satellite.r_timestamp), CURRENT_TIMESTAMP()))
                               FROM dv.l_order_customer AS l
                                 INNER JOIN dv.ls_order_customer_eff AS satellite
                                            ON (l.l_order_customer_hashkey = satellite.l_order_customer_hashkey
@@ -394,7 +394,7 @@ SET min_timestamp_link = (
 
 SET min_timestamp_satellite = (
                               SELECT
-                                DATEADD(HOUR, -4, COALESCE(MIN(satellite.r_timestamp), CURRENT_TIMESTAMP()))     
+                                DATEADD(HOUR, -4, COALESCE(MIN(satellite.r_timestamp), CURRENT_TIMESTAMP()))
                               FROM dv.l_order_customer_role_playing AS l
                                 INNER JOIN dv.ls_order_customer_role_playing_eff AS satellite
                                            ON (l.l_order_customer_role_playing_hashkey = satellite.l_order_customer_role_playing_hashkey

--- a/test/sql/expected_result_data_vault_load.sql
+++ b/test/sql/expected_result_data_vault_load.sql
@@ -12,7 +12,7 @@ CREATE OR REPLACE TABLE dv_stg.orders_20190806_000000
 -- This is unlikely to happen, but still better to play it on the safe side.
 SET min_timestamp = (
                     SELECT
-                      COALESCE(MIN(target.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
+                      DATEADD(HOUR, -4, COALESCE(MIN(target.r_timestamp), CURRENT_TIMESTAMP()))
                     FROM dv_stg.orders_20190806_000000 AS staging
                       INNER JOIN dv.h_customer AS target
                                  ON (staging.h_customer_hashkey = target.h_customer_hashkey)
@@ -43,7 +43,7 @@ MERGE INTO dv.h_customer AS target
 -- This is unlikely to happen, but still better to play it on the safe side.
 SET min_timestamp = (
                     SELECT
-                      COALESCE(MIN(target.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
+                      DATEADD(HOUR, -4, COALESCE(MIN(target.r_timestamp), CURRENT_TIMESTAMP()))
                     FROM dv_stg.orders_20190806_000000 AS staging
                       INNER JOIN dv.h_customer AS target
                                  ON (staging.h_customer_role_playing_hashkey = target.h_customer_hashkey)
@@ -74,7 +74,7 @@ MERGE INTO dv.h_customer AS target
 -- This is unlikely to happen, but still better to play it on the safe side.
 SET min_timestamp = (
                     SELECT
-                      COALESCE(MIN(target.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
+                      DATEADD(HOUR, -4, COALESCE(MIN(target.r_timestamp), CURRENT_TIMESTAMP()))
                     FROM dv_stg.orders_20190806_000000 AS staging
                       INNER JOIN dv.h_order AS target
                                  ON (staging.h_order_hashkey = target.h_order_hashkey)
@@ -105,7 +105,7 @@ MERGE INTO dv.h_order AS target
 -- This is unlikely to happen, but still better to play it on the safe side.
 SET min_timestamp = (
                     SELECT
-                      COALESCE(MIN(target.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
+                      DATEADD(HOUR, -4, COALESCE(MIN(target.r_timestamp), CURRENT_TIMESTAMP()))
                     FROM dv_stg.orders_20190806_000000 AS staging
                       INNER JOIN dv.l_order_customer AS target
                                  ON (staging.l_order_customer_hashkey = target.l_order_customer_hashkey)
@@ -136,7 +136,7 @@ MERGE INTO dv.l_order_customer AS target
 -- This is unlikely to happen, but still better to play it on the safe side.
 SET min_timestamp = (
                     SELECT
-                      COALESCE(MIN(target.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
+                      DATEADD(HOUR, -4, COALESCE(MIN(target.r_timestamp), CURRENT_TIMESTAMP()))
                     FROM dv_stg.orders_20190806_000000 AS staging
                       INNER JOIN dv.l_order_customer_role_playing AS target
                                  ON (staging.l_order_customer_role_playing_hashkey = target.l_order_customer_role_playing_hashkey)
@@ -267,7 +267,7 @@ MERGE INTO dv.hs_customer AS satellite
 -- This is unlikely to happen, but still better to play it on the safe side.
 SET min_timestamp_link = (
                          SELECT
-                           COALESCE(MIN(l.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
+                           DATEADD(HOUR, -4, COALESCE(MIN(l.r_timestamp), CURRENT_TIMESTAMP()))
                          FROM dv.l_order_customer AS l
                            INNER JOIN dv_stg.orders_20190806_000000 AS staging
                                       ON (l.h_customer_hashkey = staging.h_customer_hashkey)
@@ -275,8 +275,7 @@ SET min_timestamp_link = (
 
 SET min_timestamp_satellite = (
                               SELECT
-                                COALESCE(MIN(satellite.r_timestamp),
-                                         DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
+                                DATEADD(HOUR, -4, COALESCE(MIN(satellite.r_timestamp), CURRENT_TIMESTAMP()))     
                               FROM dv.l_order_customer AS l
                                 INNER JOIN dv.ls_order_customer_eff AS satellite
                                            ON (l.l_order_customer_hashkey = satellite.l_order_customer_hashkey
@@ -387,7 +386,7 @@ MERGE INTO dv.ls_order_customer_eff AS satellite
 -- This is unlikely to happen, but still better to play it on the safe side.
 SET min_timestamp_link = (
                          SELECT
-                           COALESCE(MIN(l.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
+                           DATEADD(HOUR, -4, COALESCE(MIN(l.r_timestamp), CURRENT_TIMESTAMP()))
                          FROM dv.l_order_customer_role_playing AS l
                            INNER JOIN dv_stg.orders_20190806_000000 AS staging
                                       ON (l.h_customer_role_playing_hashkey = staging.h_customer_role_playing_hashkey)
@@ -395,8 +394,7 @@ SET min_timestamp_link = (
 
 SET min_timestamp_satellite = (
                               SELECT
-                                COALESCE(MIN(satellite.r_timestamp),
-                                         DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
+                                DATEADD(HOUR, -4, COALESCE(MIN(satellite.r_timestamp), CURRENT_TIMESTAMP()))     
                               FROM dv.l_order_customer_role_playing AS l
                                 INNER JOIN dv.ls_order_customer_role_playing_eff AS satellite
                                            ON (l.l_order_customer_role_playing_hashkey = satellite.l_order_customer_role_playing_hashkey

--- a/test/sql/expected_result_effectivity_satellite.sql
+++ b/test/sql/expected_result_effectivity_satellite.sql
@@ -15,7 +15,7 @@ SET min_timestamp_link = (
 
 SET min_timestamp_satellite = (
                               SELECT
-                                DATEADD(HOUR, -4, COALESCE(MIN(satellite.r_timestamp), CURRENT_TIMESTAMP()))     
+                                DATEADD(HOUR, -4, COALESCE(MIN(satellite.r_timestamp), CURRENT_TIMESTAMP()))
                               FROM dv.l_order_customer AS l
                                 INNER JOIN dv.ls_order_customer_eff AS satellite
                                            ON (l.l_order_customer_hashkey = satellite.l_order_customer_hashkey

--- a/test/sql/expected_result_effectivity_satellite.sql
+++ b/test/sql/expected_result_effectivity_satellite.sql
@@ -7,7 +7,7 @@
 -- This is unlikely to happen, but still better to play it on the safe side.
 SET min_timestamp_link = (
                          SELECT
-                           COALESCE(MIN(l.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
+                           DATEADD(HOUR, -4, COALESCE(MIN(l.r_timestamp), CURRENT_TIMESTAMP()))
                          FROM dv.l_order_customer AS l
                            INNER JOIN dv_stg.orders_20190806_000000 AS staging
                                       ON (l.h_customer_hashkey = staging.h_customer_hashkey)
@@ -15,8 +15,7 @@ SET min_timestamp_link = (
 
 SET min_timestamp_satellite = (
                               SELECT
-                                COALESCE(MIN(satellite.r_timestamp),
-                                         DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
+                                DATEADD(HOUR, -4, COALESCE(MIN(satellite.r_timestamp), CURRENT_TIMESTAMP()))     
                               FROM dv.l_order_customer AS l
                                 INNER JOIN dv.ls_order_customer_eff AS satellite
                                            ON (l.l_order_customer_hashkey = satellite.l_order_customer_hashkey

--- a/test/sql/expected_result_hub.sql
+++ b/test/sql/expected_result_hub.sql
@@ -7,7 +7,7 @@
 -- This is unlikely to happen, but still better to play it on the safe side.
 SET min_timestamp = (
                     SELECT
-                      COALESCE(MIN(target.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
+                      DATEADD(HOUR, -4, COALESCE(MIN(target.r_timestamp), CURRENT_TIMESTAMP()))
                     FROM dv_stg.orders_20190806_000000 AS staging
                       INNER JOIN dv.h_customer AS target
                                  ON (staging.h_customer_hashkey = target.h_customer_hashkey)

--- a/test/sql/expected_result_link.sql
+++ b/test/sql/expected_result_link.sql
@@ -7,7 +7,7 @@
 -- This is unlikely to happen, but still better to play it on the safe side.
 SET min_timestamp = (
                     SELECT
-                      COALESCE(MIN(target.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
+                      DATEADD(HOUR, -4, COALESCE(MIN(target.r_timestamp), CURRENT_TIMESTAMP()))
                     FROM dv_stg.orders_20190806_000000 AS staging
                       INNER JOIN dv.l_order_customer AS target
                                  ON (staging.l_order_customer_hashkey = target.l_order_customer_hashkey)

--- a/test/sql/expected_result_role_playing_hub.sql
+++ b/test/sql/expected_result_role_playing_hub.sql
@@ -7,7 +7,7 @@
 -- This is unlikely to happen, but still better to play it on the safe side.
 SET min_timestamp = (
                     SELECT
-                      COALESCE(MIN(target.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
+                      DATEADD(HOUR, -4, COALESCE(MIN(target.r_timestamp), CURRENT_TIMESTAMP()))
                     FROM dv_stg.orders_20190806_000000 AS staging
                       INNER JOIN dv.h_customer AS target
                                  ON (staging.h_customer_role_playing_hashkey = target.h_customer_hashkey)

--- a/test/sql/expected_result_satellite.sql
+++ b/test/sql/expected_result_satellite.sql
@@ -7,7 +7,7 @@
 -- This is unlikely to happen, but still better to play it on the safe side.
 SET min_timestamp = (
                     SELECT
-                      COALESCE(MIN(satellite.r_timestamp), DATEADD(HOUR, -4, CURRENT_TIMESTAMP()))
+                      DATEADD(HOUR, -4, COALESCE(MIN(satellite.r_timestamp), CURRENT_TIMESTAMP()))
                     FROM dv_stg.orders_20190806_000000 AS staging
                       INNER JOIN dv.hs_customer AS satellite
                                  ON (satellite.h_customer_hashkey = staging.h_customer_hashkey


### PR DESCRIPTION
The purpose of this PR is to add a "safety-net" in the calculation of the minimum record timestamp of a given target table by always going back 4 hours independently on whether the target table has matching records with the staging table or not.

This need was detected when concurrent data vault loads caused the insertion of duplicate records in effectivity satellites.

This only happened in real edge cases when 3 instances of the same capturing process were running concurrently but, anyhow, it is a real risk.

The 4 hours is a bit arbitrary, but essentially assumes that a capturing process will never take more than 4 hours to finish which is overall a good assumption given our use cases. We could go back less than 4 hours, but better to play it on the safe side as the performance differences between 4 hours or 1 hour (for example) should be minimal.