### PR TITLE
Add changelog and contributing guide to documentation

### DIFF
--- a/doc/changes.md
+++ b/doc/changes.md
@@ -1,0 +1,2 @@
+```{include} ../CHANGELOG.md
+```

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -1,0 +1,2 @@
+```{include} ../CONTRIBUTING.md
+```

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -43,3 +43,5 @@ Developer documentation
 
    development
    API documentation <api/modules>
+   contributing
+   changes

--- a/tox.ini
+++ b/tox.ini
@@ -89,6 +89,7 @@ allowlist_externals = touch
 deps =
     sphinx
     sphinx-autodoc-typehints
+    myst-parser
 commands =
     # Build apidoc
     sphinx-apidoc --implicit-namespaces -M -t doc_templates --separate -o doc/api src/diepvries
@@ -98,7 +99,7 @@ commands =
         -C \
         -D project="diepvries" \
         -D copyright="Picnic Technologies" \
-        -D extensions="sphinx.ext.autodoc,sphinx.ext.napoleon,sphinx_autodoc_typehints,sphinx.ext.graphviz" \
+        -D extensions="sphinx.ext.autodoc,sphinx.ext.napoleon,sphinx_autodoc_typehints,sphinx.ext.graphviz,myst_parser" \
         -D napoleon_google_docstring=1 \
         -D napoleon_numpy_docstring=0 \
         -D napoleon_include_init_with_doc=1 \


### PR DESCRIPTION
To make it easy to access the contributing guide and changelog in docs, this PR creates two placeholder doc files that link the Markdown files in the project root.

I added the Sphinx extension [`myst-parser`](https://myst-parser.readthedocs.io/en/v0.17.1/sphinx/intro.html) to parse Markdown files.

Previewed the generated docs locally:

![image](https://github.com/PicnicSupermarket/diepvries/assets/12967000/0549262f-2e01-4724-88b6-7ff82c16326e)
