### PR TITLE
Add support for browser authentication in `SnowflakeDeserializer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add support for external browser authentication in `SnowflakeDeserializer`.
 
 ## [0.9.1] - 2023-09-13
 ### Changed

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ packages = find:
 include_package_data = true
 package_dir = = src
 install_requires =
-    snowflake-connector-python~=3.0
+    snowflake-connector-python[secure-local-storage]~=3.0
 test_requires =
     pytest~=6.2
 

--- a/src/diepvries/deserializers/snowflake_deserializer.py
+++ b/src/diepvries/deserializers/snowflake_deserializer.py
@@ -5,7 +5,7 @@ import logging
 from collections import defaultdict
 from dataclasses import asdict, dataclass
 from functools import cached_property
-from typing import Dict, List, Optional, Type
+from typing import Dict, List, Literal, Optional, Type
 
 from snowflake.connector import DictCursor, connect
 

--- a/src/diepvries/deserializers/snowflake_deserializer.py
+++ b/src/diepvries/deserializers/snowflake_deserializer.py
@@ -5,7 +5,7 @@ import logging
 from collections import defaultdict
 from dataclasses import asdict, dataclass
 from functools import cached_property
-from typing import Dict, List, Type
+from typing import Dict, List, Optional, Type
 
 from snowflake.connector import DictCursor, connect
 
@@ -29,9 +29,19 @@ class DatabaseConfiguration:
 
     database: str
     user: str
-    password: str
     warehouse: str
     account: str
+    password: Optional[str] = None
+    authenticator: Optional[str] = "password"
+
+    def __post_init__(self):
+        """Validate input for optional attributes."""
+        if self.authenticator == "password" and not self.password:
+            raise ValueError(
+                "Password was not provided. It is a mandatory attribute when the "
+                "authenticator is `password`. Empty passwords are only allowed "
+                "when `authenticator='externalbrowser'`."
+            )
 
 
 class SnowflakeDeserializer:

--- a/src/diepvries/deserializers/snowflake_deserializer.py
+++ b/src/diepvries/deserializers/snowflake_deserializer.py
@@ -32,7 +32,7 @@ class DatabaseConfiguration:
     warehouse: str
     account: str
     password: Optional[str] = None
-    authenticator: Optional[str] = "password"
+    authenticator: Optional[Literal["password", "externalbrowser"]] = "password"
 
     def __post_init__(self):
         """Validate input for optional attributes."""

--- a/test/deserializers/test_snowflake_deserializer.py
+++ b/test/deserializers/test_snowflake_deserializer.py
@@ -206,5 +206,5 @@ def test_database_configuration_with_password_invalid_input():
             database="some_db",
             user="some_user",
             warehouse="some_warehouse",
-            account="some_account"
+            account="some_account",
         )

--- a/test/deserializers/test_snowflake_deserializer.py
+++ b/test/deserializers/test_snowflake_deserializer.py
@@ -7,7 +7,10 @@ from unittest.mock import MagicMock, PropertyMock
 import pytest
 from snowflake.connector.cursor import SnowflakeCursor
 
-from diepvries.deserializers.snowflake_deserializer import SnowflakeDeserializer
+from diepvries.deserializers.snowflake_deserializer import (
+    DatabaseConfiguration,
+    SnowflakeDeserializer,
+)
 from diepvries.driving_key_field import DrivingKeyField
 from diepvries.effectivity_satellite import EffectivitySatellite
 from diepvries.field import Field
@@ -194,3 +197,14 @@ def test_deserialized_target_tables(
                 table, RolePlayingHub
             ):
                 compare_tables(table.parent_table, h_customer)
+
+
+def test_database_configuration_with_password_invalid_input():
+    """Test `DatabaseConfiguration` without password, using `password` authenticator."""
+    with pytest.raises(ValueError):
+        _ = DatabaseConfiguration(
+            database="some_db",
+            user="some_user",
+            warehouse="some_warehouse",
+            account="some_account"
+        )


### PR DESCRIPTION
The purpose of this PR is to allow Snowflake authentication to be done using `externabrowser`.

### Implementation details

- Make `password` argument optional in `DatabaseConfiguration`
- Add `authenticator` attribute to `DatabaseConfiguration`
- Validate input in `DatabaseConfiguration`, ensuring that the instantiation fails when the password is empty and the `authenticator=password`.