### PR TITLE
Stop using invalid `password` authenticator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Stop using invalid `password` authenticator.
+
 ## [1.0.0]
 ### Added
 - Add support for external browser authentication in `SnowflakeDeserializer`.

--- a/src/diepvries/deserializers/snowflake_deserializer.py
+++ b/src/diepvries/deserializers/snowflake_deserializer.py
@@ -32,14 +32,14 @@ class DatabaseConfiguration:
     warehouse: str
     account: str
     password: Optional[str] = None
-    authenticator: Optional[Literal["password", "externalbrowser"]] = "password"
+    authenticator: Optional[Literal["externalbrowser"]] = None
 
     def __post_init__(self):
         """Validate input for optional attributes."""
-        if self.authenticator == "password" and not self.password:
+        if self.authenticator is None and not self.password:
             raise ValueError(
-                "Password was not provided. It is a mandatory attribute when the "
-                "authenticator is `password`. Empty passwords are only allowed "
+                "Password was not provided. It is a mandatory attribute when an "
+                "authenticator is not specified. Empty passwords are only allowed "
                 "when `authenticator='externalbrowser'`."
             )
 

--- a/src/diepvries/deserializers/snowflake_deserializer.py
+++ b/src/diepvries/deserializers/snowflake_deserializer.py
@@ -5,10 +5,9 @@ import logging
 from collections import defaultdict
 from dataclasses import asdict, dataclass
 from functools import cached_property
-from typing import Dict, List, Optional, Type
+from typing import Dict, List, Literal, Optional, Type
 
 from snowflake.connector import DictCursor, connect
-from snowflake.connector.network import DEFAULT_AUTHENTICATOR
 
 from .. import TABLE_PREFIXES, FieldDataType, FixedPrefixLoggerAdapter, TableType
 from ..driving_key_field import DrivingKeyField
@@ -33,15 +32,15 @@ class DatabaseConfiguration:
     warehouse: str
     account: str
     password: Optional[str] = None
-    authenticator: Optional[str] = DEFAULT_AUTHENTICATOR
+    authenticator: Optional[Literal["externalbrowser"]] = None
 
     def __post_init__(self):
         """Validate input for optional attributes."""
-        if self.authenticator == DEFAULT_AUTHENTICATOR and not self.password:
+        if self.authenticator is None and not self.password:
             raise ValueError(
-                f"Password was not provided. It is a mandatory attribute when the "
-                f"authenticator is not `{DEFAULT_AUTHENTICATOR}`. Empty passwords are "
-                f"only allowed when `authenticator='externalbrowser'`."
+                "Password was not provided. It is a mandatory attribute when an "
+                "authenticator is not specified. Empty passwords are only allowed "
+                "when `authenticator='externalbrowser'`."
             )
 
 

--- a/src/diepvries/deserializers/snowflake_deserializer.py
+++ b/src/diepvries/deserializers/snowflake_deserializer.py
@@ -5,9 +5,10 @@ import logging
 from collections import defaultdict
 from dataclasses import asdict, dataclass
 from functools import cached_property
-from typing import Dict, List, Literal, Optional, Type
+from typing import Dict, List, Optional, Type
 
 from snowflake.connector import DictCursor, connect
+from snowflake.connector.network import DEFAULT_AUTHENTICATOR
 
 from .. import TABLE_PREFIXES, FieldDataType, FixedPrefixLoggerAdapter, TableType
 from ..driving_key_field import DrivingKeyField
@@ -32,15 +33,15 @@ class DatabaseConfiguration:
     warehouse: str
     account: str
     password: Optional[str] = None
-    authenticator: Optional[Literal["externalbrowser"]] = None
+    authenticator: Optional[str] = DEFAULT_AUTHENTICATOR
 
     def __post_init__(self):
         """Validate input for optional attributes."""
-        if self.authenticator is None and not self.password:
+        if self.authenticator == DEFAULT_AUTHENTICATOR and not self.password:
             raise ValueError(
-                "Password was not provided. It is a mandatory attribute when an "
-                "authenticator is not specified. Empty passwords are only allowed "
-                "when `authenticator='externalbrowser'`."
+                f"Password was not provided. It is a mandatory attribute when the "
+                f"authenticator is not `{DEFAULT_AUTHENTICATOR}`. Empty passwords are "
+                f"only allowed when `authenticator='externalbrowser'`."
             )
 
 

--- a/test/deserializers/test_snowflake_deserializer.py
+++ b/test/deserializers/test_snowflake_deserializer.py
@@ -200,7 +200,7 @@ def test_deserialized_target_tables(
 
 
 def test_database_configuration_with_password_invalid_input():
-    """Test `DatabaseConfiguration` - no password nor authenticator=externalbrowser."""
+    """Test `DatabaseConfiguration` without password nor an `authenticator`."""
     with pytest.raises(ValueError):
         _ = DatabaseConfiguration(
             database="some_db",

--- a/test/deserializers/test_snowflake_deserializer.py
+++ b/test/deserializers/test_snowflake_deserializer.py
@@ -200,7 +200,7 @@ def test_deserialized_target_tables(
 
 
 def test_database_configuration_with_password_invalid_input():
-    """Test `DatabaseConfiguration` without password nor an `authenticator`."""
+    """Test `DatabaseConfiguration` - no password nor authenticator=externalbrowser."""
     with pytest.raises(ValueError):
         _ = DatabaseConfiguration(
             database="some_db",

--- a/test/deserializers/test_snowflake_deserializer.py
+++ b/test/deserializers/test_snowflake_deserializer.py
@@ -200,7 +200,7 @@ def test_deserialized_target_tables(
 
 
 def test_database_configuration_with_password_invalid_input():
-    """Test `DatabaseConfiguration` without password, using `password` authenticator."""
+    """Test `DatabaseConfiguration` without password nor an `authenticator`."""
     with pytest.raises(ValueError):
         _ = DatabaseConfiguration(
             database="some_db",


### PR DESCRIPTION
The purpose of this PR is to fix a bug in the authentication behaviour, introduced in this [PR](https://github.com/PicnicSupermarket/diepvries/pull/58).

While the feature referenced above worked successfully for cases when the `authenticator=externalbrowser` it was not working in cases where an authentication with user and password was intended, as the value `password` is invalid for the `authenticator` parameter of `snowflake-connector-python`.

As the authentication with user/password is the default authentication behaviour of the snowflake connector, the implementation was changed for `DatabaseConfiguration.authenticator` to accept either `externalbrowser` or default to the `DEFAULT_AUTHENTICATOR` from `snowflake-connector`, the latter triggering a successful authentication using user and password