### PR TITLE
Fix GitHub actions workflow

### DIFF
--- a/.github/workflows/build-deploy-and-release.yml
+++ b/.github/workflows/build-deploy-and-release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install dependencies
         run: python -m pip install tox
       - name: Run tox build

--- a/.github/workflows/pages-build-and-deploy.yml
+++ b/.github/workflows/pages-build-and-deploy.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           sudo apt update

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Python
 __pycache__/
 venv/
+.venv/
 
 # Python packaging
 build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `actions/setup-python` updated to `v6`
   - `actions/upload-pages-artifact` updated to `v4`
 
+### Fixed
+- Quote Python versions in GitHub workflows' YAML files to ensure `3.10` is not interpreted as a number (`3.1`).
+
 ## [1.0.1] - 2024-06-11
 ### Fixed
 - Stop using invalid `password` authenticator.


### PR DESCRIPTION
Fixed GitHub actions workflow by quoting the Python version used, ensuring that `3.10` is not interpreted as a number (`3.1`).